### PR TITLE
Remove redundant config re-resolution in doctor diagnostics

### DIFF
--- a/omop_alchemy/cdm/handlers/timeline/event_timeline.py
+++ b/omop_alchemy/cdm/handlers/timeline/event_timeline.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 from datetime import datetime, time, date
 from typing import Optional, Mapping, Any,  List
 import json
+import hashlib
 from dataclasses import dataclass
 from typing import Protocol, Union, Literal
 
@@ -189,6 +190,12 @@ class ClinicalEvent:
     def to_json(self: ClinicalEventProtocol) -> str:
         return json.dumps(self.to_dict(), ensure_ascii=False)
 
+    def fingerprint(self: ClinicalEventProtocol) -> str:
+        # Override SerialisableTableInterface.fingerprint(). 
+        # to_json() does not have "include_nulls" due to different behaviour
+        # (its dict is a curated timeline projection, not a raw column dump).
+        return hashlib.sha256(self.to_json().encode("utf-8")).hexdigest()
+
 
 
 class Condition_Event(Condition_Occurrence, ClinicalEvent):
@@ -201,7 +208,7 @@ class Condition_Event(Condition_Occurrence, ClinicalEvent):
     )
 
 
-class Measurement_Event(ClinicalEvent, Measurement):  # type: ignore[misc]
+class Measurement_Event(ClinicalEvent, Measurement):  # ty: ignore[invalid-method-override]
 
     _mapping = EventMapping(
         concept_field="measurement_concept_id",

--- a/omop_alchemy/cdm/handlers/timeline/event_timeline.py
+++ b/omop_alchemy/cdm/handlers/timeline/event_timeline.py
@@ -5,7 +5,6 @@ from sqlalchemy import select
 from datetime import datetime, time, date
 from typing import Optional, Mapping, Any,  List
 import json
-import hashlib
 from dataclasses import dataclass
 from typing import Protocol, Union, Literal
 
@@ -190,12 +189,6 @@ class ClinicalEvent:
     def to_json(self: ClinicalEventProtocol) -> str:
         return json.dumps(self.to_dict(), ensure_ascii=False)
 
-    def fingerprint(self: ClinicalEventProtocol) -> str:
-        # Override SerialisableTableInterface.fingerprint(). 
-        # to_json() does not have "include_nulls" due to different behaviour
-        # (its dict is a curated timeline projection, not a raw column dump).
-        return hashlib.sha256(self.to_json().encode("utf-8")).hexdigest()
-
 
 
 class Condition_Event(Condition_Occurrence, ClinicalEvent):
@@ -208,7 +201,7 @@ class Condition_Event(Condition_Occurrence, ClinicalEvent):
     )
 
 
-class Measurement_Event(ClinicalEvent, Measurement):  # ty: ignore[invalid-method-override]
+class Measurement_Event(ClinicalEvent, Measurement):
 
     _mapping = EventMapping(
         concept_field="measurement_concept_id",

--- a/omop_alchemy/maintenance/cli_schema.py
+++ b/omop_alchemy/maintenance/cli_schema.py
@@ -99,7 +99,9 @@ def doctor_command(
 ) -> None:
     """Run a read-only maintenance health check across connection readiness, schema drift, and FK state."""
     with console.status("Running maintenance doctor checks..."):
-        report = collect_doctor_report(vocabulary_included=vocabulary_included, deep=deep)
+        report = collect_doctor_report(
+            engine=engine, vocabulary_included=vocabulary_included, deep=deep
+        )
     console.print(render_info_environment(report.info))
     console.print(render_info_database(report.info))
     console.print(render_doctor_checks(report.checks))

--- a/omop_alchemy/maintenance/cli_schema_doctor.py
+++ b/omop_alchemy/maintenance/cli_schema_doctor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 
 import sqlalchemy as sa
@@ -155,7 +156,7 @@ def _build_recommendations(
 
 def collect_doctor_report(
     *,
-    engine: sa.engine.Engine,
+    engine: sa.engine.Engine | None = None,
     vocabulary_included: bool = True,
     deep: bool = False,
 ) -> DoctorReport:
@@ -163,195 +164,218 @@ def collect_doctor_report(
 
     Parameters
     ----------
-    engine : sa.engine.Engine
-        Already-resolved CDM engine (from the ``@omop_command`` decorator),
+    engine : sa.engine.Engine, optional
+        Already-resolved CDM engine (e.g. from the ``@omop_command`` decorator),
         reused for the deep checks below instead of re-resolving config.
+
+        .. deprecated::
+            Omitting this and letting the function resolve its own engine is
+            deprecated and will be required in 2.0. Pass the already-resolved
+            engine instead.
     """
-    info = collect_maintenance_info(vocabulary_included=vocabulary_included)
-
-    checks = [
-        DoctorCheck(
-            name="connection",
-            status="passed" if info.connection_ready else "failed",
-            detail=(
-                "Target database connection succeeded."
-                if info.connection_ready
-                else info.connection_error or info.engine_error or "Connection could not be established."
-            ),
+    owns_engine = engine is None
+    if owns_engine:
+        warnings.warn(
+            "collect_doctor_report() without an explicit engine= is deprecated "
+            "and will be required in 2.0. Pass the already-resolved engine "
+            "(e.g. from @omop_command) instead of letting this function "
+            "re-resolve config a second time.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-    ]
+        from omop_alchemy.config import create_cdm_engine, get_cdm_context
+        _, resolved = get_cdm_context()
+        engine = create_cdm_engine(resolved)
 
-    reconciliation: SchemaReconciliationReport | None = None
-    foreign_key_status: tuple[ForeignKeyStatusResult, ...] | None = None
-    foreign_key_validation: ForeignKeyValidationReport | None = None
+    try:
+        info = collect_maintenance_info(vocabulary_included=vocabulary_included)
 
-    if info.connection_ready:
-        db_schema = info.db_schema
-        missing_table_count = info.missing_table_count or 0
-        checks.append(
+        checks = [
             DoctorCheck(
-                name="managed tables",
-                status="passed" if missing_table_count == 0 else "warning",
+                name="connection",
+                status="passed" if info.connection_ready else "failed",
                 detail=(
-                    "All selected ORM-managed tables exist."
-                    if missing_table_count == 0
-                    else f"{missing_table_count} selected table(s) are missing."
+                    "Target database connection succeeded."
+                    if info.connection_ready
+                    else info.connection_error or info.engine_error or "Connection could not be established."
                 ),
             )
-        )
+        ]
 
-        if deep:
-            reconciliation = reconcile_schema(
-                engine,
-                db_schema=db_schema,
-                vocabulary_included=vocabulary_included,
-            )
-            checks.append(
-                DoctorCheck(
-                    name="schema drift",
-                    status="passed" if not reconciliation.issues else "warning",
-                    detail=(
-                        "ORM metadata matches the target database."
-                        if not reconciliation.issues
-                        else f"{len(reconciliation.issues)} difference(s) detected."
-                    ),
-                )
-            )
-        else:
-            checks.append(
-                DoctorCheck(
-                    name="schema drift",
-                    status="skipped",
-                    detail="Run `omop-alchemy doctor --deep` to reconcile ORM metadata against the target database.",
-                )
-            )
+        reconciliation: SchemaReconciliationReport | None = None
+        foreign_key_status: tuple[ForeignKeyStatusResult, ...] | None = None
+        foreign_key_validation: ForeignKeyValidationReport | None = None
 
-        if info.backend == SupportedDialect.POSTGRESQL:
-            foreign_key_status = tuple(
-                collect_foreign_key_trigger_status(
-                    engine,
-                    db_schema=db_schema,
-                    vocabulary_included=vocabulary_included,
-                )
-            )
-            disabled_tables = sum(
-                item.disabled_trigger_count > 0 for item in foreign_key_status
-            )
+        if info.connection_ready:
+            db_schema = info.db_schema
+            missing_table_count = info.missing_table_count or 0
             checks.append(
                 DoctorCheck(
-                    name="foreign keys",
-                    status="passed" if disabled_tables == 0 else "warning",
+                    name="managed tables",
+                    status="passed" if missing_table_count == 0 else "warning",
                     detail=(
-                        "All inspected RI triggers are enabled."
-                        if disabled_tables == 0
-                        else f"{disabled_tables} table(s) still have disabled RI triggers."
+                        "All selected ORM-managed tables exist."
+                        if missing_table_count == 0
+                        else f"{missing_table_count} selected table(s) are missing."
                     ),
                 )
             )
 
             if deep:
-                foreign_key_validation = validate_foreign_key_constraints(
+                reconciliation = reconcile_schema(
                     engine,
                     db_schema=db_schema,
                     vocabulary_included=vocabulary_included,
                 )
-                violating_tables = sum(
-                    result.status == "failed" for result in foreign_key_validation.results
-                )
                 checks.append(
                     DoctorCheck(
-                        name="foreign key validation",
-                        status="passed" if violating_tables == 0 else "failed",
+                        name="schema drift",
+                        status="passed" if not reconciliation.issues else "warning",
                         detail=(
-                            "All selected foreign key relationships passed validation."
-                            if violating_tables == 0
-                            else f"{violating_tables} table(s) have violating foreign key rows."
+                            "ORM metadata matches the target database."
+                            if not reconciliation.issues
+                            else f"{len(reconciliation.issues)} difference(s) detected."
                         ),
                     )
                 )
             else:
                 checks.append(
                     DoctorCheck(
+                        name="schema drift",
+                        status="skipped",
+                        detail="Run `omop-alchemy doctor --deep` to reconcile ORM metadata against the target database.",
+                    )
+                )
+
+            if info.backend == SupportedDialect.POSTGRESQL:
+                foreign_key_status = tuple(
+                    collect_foreign_key_trigger_status(
+                        engine,
+                        db_schema=db_schema,
+                        vocabulary_included=vocabulary_included,
+                    )
+                )
+                disabled_tables = sum(
+                    item.disabled_trigger_count > 0 for item in foreign_key_status
+                )
+                checks.append(
+                    DoctorCheck(
+                        name="foreign keys",
+                        status="passed" if disabled_tables == 0 else "warning",
+                        detail=(
+                            "All inspected RI triggers are enabled."
+                            if disabled_tables == 0
+                            else f"{disabled_tables} table(s) still have disabled RI triggers."
+                        ),
+                    )
+                )
+
+                if deep:
+                    foreign_key_validation = validate_foreign_key_constraints(
+                        engine,
+                        db_schema=db_schema,
+                        vocabulary_included=vocabulary_included,
+                    )
+                    violating_tables = sum(
+                        result.status == "failed" for result in foreign_key_validation.results
+                    )
+                    checks.append(
+                        DoctorCheck(
+                            name="foreign key validation",
+                            status="passed" if violating_tables == 0 else "failed",
+                            detail=(
+                                "All selected foreign key relationships passed validation."
+                                if violating_tables == 0
+                                else f"{violating_tables} table(s) have violating foreign key rows."
+                            ),
+                        )
+                    )
+                else:
+                    checks.append(
+                        DoctorCheck(
+                            name="foreign key validation",
+                            status="skipped",
+                            detail="Run `omop-alchemy doctor --deep` to validate selected foreign key relationships.",
+                        )
+                    )
+            else:
+                checks.append(
+                    DoctorCheck(
+                        name="foreign keys",
+                        status="skipped",
+                        detail="Foreign key trigger inspection is only available on PostgreSQL.",
+                    )
+                )
+                checks.append(
+                    DoctorCheck(
                         name="foreign key validation",
                         status="skipped",
-                        detail="Run `omop-alchemy doctor --deep` to validate selected foreign key relationships.",
+                        detail="Foreign key validation is only available on PostgreSQL.",
                     )
                 )
         else:
-            checks.append(
-                DoctorCheck(
-                    name="foreign keys",
-                    status="skipped",
-                    detail="Foreign key trigger inspection is only available on PostgreSQL.",
+            checks.extend(
+                (
+                    DoctorCheck(
+                        name="managed tables",
+                        status="skipped",
+                        detail="Skipped because the database connection is not ready.",
+                    ),
+                    DoctorCheck(
+                        name="foreign keys",
+                        status="skipped",
+                        detail="Skipped because the database connection is not ready.",
+                    ),
+                    DoctorCheck(
+                        name="schema drift",
+                        status="skipped",
+                        detail="Skipped because the database connection is not ready.",
+                    ),
+                    DoctorCheck(
+                        name="foreign key validation",
+                        status="skipped",
+                        detail="Skipped because the database connection is not ready.",
+                    ),
                 )
             )
+
+        if info.backend == SupportedDialect.POSTGRESQL:
+            backup_tools_ready = info.pg_dump_path is not None and (
+                info.pg_restore_path is not None or info.psql_path is not None
+            )
             checks.append(
                 DoctorCheck(
-                    name="foreign key validation",
-                    status="skipped",
-                    detail="Foreign key validation is only available on PostgreSQL.",
+                    name="backup tooling",
+                    status="passed" if backup_tools_ready else "warning",
+                    detail=(
+                        "PostgreSQL backup and restore client tools are available."
+                        if backup_tools_ready
+                        else "PostgreSQL client tools are incomplete on this machine."
+                    ),
                 )
             )
-    else:
-        checks.extend(
-            (
+        else:
+            checks.append(
                 DoctorCheck(
-                    name="managed tables",
+                    name="backup tooling",
                     status="skipped",
-                    detail="Skipped because the database connection is not ready.",
-                ),
-                DoctorCheck(
-                    name="foreign keys",
-                    status="skipped",
-                    detail="Skipped because the database connection is not ready.",
-                ),
-                DoctorCheck(
-                    name="schema drift",
-                    status="skipped",
-                    detail="Skipped because the database connection is not ready.",
-                ),
-                DoctorCheck(
-                    name="foreign key validation",
-                    status="skipped",
-                    detail="Skipped because the database connection is not ready.",
-                ),
+                    detail="Backup and restore tooling checks are only relevant for PostgreSQL targets.",
+                )
             )
-        )
 
-    if info.backend == SupportedDialect.POSTGRESQL:
-        backup_tools_ready = info.pg_dump_path is not None and (
-            info.pg_restore_path is not None or info.psql_path is not None
-        )
-        checks.append(
-            DoctorCheck(
-                name="backup tooling",
-                status="passed" if backup_tools_ready else "warning",
-                detail=(
-                    "PostgreSQL backup and restore client tools are available."
-                    if backup_tools_ready
-                    else "PostgreSQL client tools are incomplete on this machine."
-                ),
-            )
-        )
-    else:
-        checks.append(
-            DoctorCheck(
-                name="backup tooling",
-                status="skipped",
-                detail="Backup and restore tooling checks are only relevant for PostgreSQL targets.",
-            )
-        )
-
-    return DoctorReport(
-        info=info,
-        checks=tuple(checks),
-        recommendations=_build_recommendations(
+        return DoctorReport(
             info=info,
+            checks=tuple(checks),
+            recommendations=_build_recommendations(
+                info=info,
+                reconciliation=reconciliation,
+                foreign_key_status=foreign_key_status,
+                foreign_key_validation=foreign_key_validation,
+            ),
             reconciliation=reconciliation,
             foreign_key_status=foreign_key_status,
             foreign_key_validation=foreign_key_validation,
-        ),
-        reconciliation=reconciliation,
-        foreign_key_status=foreign_key_status,
-        foreign_key_validation=foreign_key_validation,
-    )
+        )
+    finally:
+        if owns_engine:
+            engine.dispose()

--- a/omop_alchemy/maintenance/cli_schema_doctor.py
+++ b/omop_alchemy/maintenance/cli_schema_doctor.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import sqlalchemy as sa
+
 from omop_alchemy.backends.resolve import SupportedDialect
 
 from .cli_foreign_keys import (
@@ -153,10 +155,18 @@ def _build_recommendations(
 
 def collect_doctor_report(
     *,
+    engine: sa.engine.Engine,
     vocabulary_included: bool = True,
     deep: bool = False,
 ) -> DoctorReport:
-    """Run all maintenance health checks and return a prioritised report with recommendations."""
+    """Run all maintenance health checks and return a prioritised report with recommendations.
+
+    Parameters
+    ----------
+    engine : sa.engine.Engine
+        Already-resolved CDM engine (from the ``@omop_command`` decorator),
+        reused for the deep checks below instead of re-resolving config.
+    """
     info = collect_maintenance_info(vocabulary_included=vocabulary_included)
 
     checks = [
@@ -176,118 +186,112 @@ def collect_doctor_report(
     foreign_key_validation: ForeignKeyValidationReport | None = None
 
     if info.connection_ready:
-        from omop_alchemy.config import create_cdm_engine, get_cdm_context
-        _, resolved = get_cdm_context()
-        engine = create_cdm_engine(resolved)
-        db_schema = resolved.cdm_schema
-        try:
-            missing_table_count = info.missing_table_count or 0
+        db_schema = info.db_schema
+        missing_table_count = info.missing_table_count or 0
+        checks.append(
+            DoctorCheck(
+                name="managed tables",
+                status="passed" if missing_table_count == 0 else "warning",
+                detail=(
+                    "All selected ORM-managed tables exist."
+                    if missing_table_count == 0
+                    else f"{missing_table_count} selected table(s) are missing."
+                ),
+            )
+        )
+
+        if deep:
+            reconciliation = reconcile_schema(
+                engine,
+                db_schema=db_schema,
+                vocabulary_included=vocabulary_included,
+            )
             checks.append(
                 DoctorCheck(
-                    name="managed tables",
-                    status="passed" if missing_table_count == 0 else "warning",
+                    name="schema drift",
+                    status="passed" if not reconciliation.issues else "warning",
                     detail=(
-                        "All selected ORM-managed tables exist."
-                        if missing_table_count == 0
-                        else f"{missing_table_count} selected table(s) are missing."
+                        "ORM metadata matches the target database."
+                        if not reconciliation.issues
+                        else f"{len(reconciliation.issues)} difference(s) detected."
+                    ),
+                )
+            )
+        else:
+            checks.append(
+                DoctorCheck(
+                    name="schema drift",
+                    status="skipped",
+                    detail="Run `omop-alchemy doctor --deep` to reconcile ORM metadata against the target database.",
+                )
+            )
+
+        if info.backend == SupportedDialect.POSTGRESQL:
+            foreign_key_status = tuple(
+                collect_foreign_key_trigger_status(
+                    engine,
+                    db_schema=db_schema,
+                    vocabulary_included=vocabulary_included,
+                )
+            )
+            disabled_tables = sum(
+                item.disabled_trigger_count > 0 for item in foreign_key_status
+            )
+            checks.append(
+                DoctorCheck(
+                    name="foreign keys",
+                    status="passed" if disabled_tables == 0 else "warning",
+                    detail=(
+                        "All inspected RI triggers are enabled."
+                        if disabled_tables == 0
+                        else f"{disabled_tables} table(s) still have disabled RI triggers."
                     ),
                 )
             )
 
             if deep:
-                reconciliation = reconcile_schema(
+                foreign_key_validation = validate_foreign_key_constraints(
                     engine,
                     db_schema=db_schema,
                     vocabulary_included=vocabulary_included,
                 )
-                checks.append(
-                    DoctorCheck(
-                        name="schema drift",
-                        status="passed" if not reconciliation.issues else "warning",
-                        detail=(
-                            "ORM metadata matches the target database."
-                            if not reconciliation.issues
-                            else f"{len(reconciliation.issues)} difference(s) detected."
-                        ),
-                    )
-                )
-            else:
-                checks.append(
-                    DoctorCheck(
-                        name="schema drift",
-                        status="skipped",
-                        detail="Run `omop-alchemy doctor --deep` to reconcile ORM metadata against the target database.",
-                    )
-                )
-
-            if info.backend == SupportedDialect.POSTGRESQL:
-                foreign_key_status = tuple(
-                    collect_foreign_key_trigger_status(
-                        engine,
-                        db_schema=db_schema,
-                        vocabulary_included=vocabulary_included,
-                    )
-                )
-                disabled_tables = sum(
-                    item.disabled_trigger_count > 0 for item in foreign_key_status
-                )
-                checks.append(
-                    DoctorCheck(
-                        name="foreign keys",
-                        status="passed" if disabled_tables == 0 else "warning",
-                        detail=(
-                            "All inspected RI triggers are enabled."
-                            if disabled_tables == 0
-                            else f"{disabled_tables} table(s) still have disabled RI triggers."
-                        ),
-                    )
-                )
-
-                if deep:
-                    foreign_key_validation = validate_foreign_key_constraints(
-                        engine,
-                        db_schema=db_schema,
-                        vocabulary_included=vocabulary_included,
-                    )
-                    violating_tables = sum(
-                        result.status == "failed" for result in foreign_key_validation.results
-                    )
-                    checks.append(
-                        DoctorCheck(
-                            name="foreign key validation",
-                            status="passed" if violating_tables == 0 else "failed",
-                            detail=(
-                                "All selected foreign key relationships passed validation."
-                                if violating_tables == 0
-                                else f"{violating_tables} table(s) have violating foreign key rows."
-                            ),
-                        )
-                    )
-                else:
-                    checks.append(
-                        DoctorCheck(
-                            name="foreign key validation",
-                            status="skipped",
-                            detail="Run `omop-alchemy doctor --deep` to validate selected foreign key relationships.",
-                        )
-                    )
-            else:
-                checks.append(
-                    DoctorCheck(
-                        name="foreign keys",
-                        status="skipped",
-                        detail="Foreign key trigger inspection is only available on PostgreSQL.",
-                    )
+                violating_tables = sum(
+                    result.status == "failed" for result in foreign_key_validation.results
                 )
                 checks.append(
                     DoctorCheck(
                         name="foreign key validation",
-                        status="skipped",
-                        detail="Foreign key validation is only available on PostgreSQL.",
+                        status="passed" if violating_tables == 0 else "failed",
+                        detail=(
+                            "All selected foreign key relationships passed validation."
+                            if violating_tables == 0
+                            else f"{violating_tables} table(s) have violating foreign key rows."
+                        ),
                     )
                 )
-        finally:
-            engine.dispose()
+            else:
+                checks.append(
+                    DoctorCheck(
+                        name="foreign key validation",
+                        status="skipped",
+                        detail="Run `omop-alchemy doctor --deep` to validate selected foreign key relationships.",
+                    )
+                )
+        else:
+            checks.append(
+                DoctorCheck(
+                    name="foreign keys",
+                    status="skipped",
+                    detail="Foreign key trigger inspection is only available on PostgreSQL.",
+                )
+            )
+            checks.append(
+                DoctorCheck(
+                    name="foreign key validation",
+                    status="skipped",
+                    detail="Foreign key validation is only available on PostgreSQL.",
+                )
+            )
     else:
         checks.extend(
             (

--- a/omop_alchemy/maintenance/cli_schema_info.py
+++ b/omop_alchemy/maintenance/cli_schema_info.py
@@ -8,7 +8,7 @@ import importlib.util
 import shutil
 
 import sqlalchemy as sa
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import ArgumentError, SQLAlchemyError
 
 from oa_configurator import Resolver, load_stack_config
 from oa_configurator.loader import DEFAULT_CONFIG_PATH
@@ -347,13 +347,15 @@ def collect_maintenance_info(
         raw_url = sa.engine.make_url(resolved.database.url)
         engine_url = raw_url.render_as_string(hide_password=True)
         backend = raw_url.get_backend_name()
-        from omop_alchemy.config import create_cdm_engine
-        engine = create_cdm_engine(resolved)
-        engine_created = True
-    except RuntimeError as exc:
-        engine_error = str(exc)
-    except Exception as exc:
+    except (FileNotFoundError, ValueError, ArgumentError, KeyError) as exc:
         engine_error = f"Could not resolve engine configuration: {exc}"
+    else:
+        from omop_alchemy.config import create_cdm_engine
+        try:
+            engine = create_cdm_engine(resolved)
+            engine_created = True
+        except RuntimeError as exc:
+            engine_error = str(exc)
 
     if engine is not None:
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
   "requests>=2.33.0",
   "pytest>=9.0.3",
   "pytest-cov>=4.0",
-  "ty>=0.0.59",
+  "ty==0.0.61",
   "ruff>=0.4",
   "mkdocs-material>=9.7.1",
   "mkdocstrings-python>=2.0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -14,15 +14,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "alabaster"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a6/f8/d9c74d0daf3f742840fd818d69cfae176fa332022fd44e3469487d5a9420/alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e", size = 24210, upload-time = "2024-07-26T18:15:03.762Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b", size = 13929, upload-time = "2024-07-26T18:15:02.05Z" },
-]
-
-[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -352,15 +343,6 @@ wheels = [
 ]
 
 [[package]]
-name = "docutils"
-version = "0.22.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
-]
-
-[[package]]
 name = "editorconfig"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -399,9 +381,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2", size = 286220, upload-time = "2026-05-20T13:07:28.463Z" },
     { url = "https://files.pythonhosted.org/packages/38/ff/a4f436709716965eaab9f36ea7b906c8a927fbe32fb1372a2071d964f6b1/greenlet-3.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffea73584b216150eab159b6d12348fb253e68757974de1e2c40d8a318ac89ed", size = 601585, upload-time = "2026-05-20T14:00:06.141Z" },
     { url = "https://files.pythonhosted.org/packages/65/ad/54bc3fcee3ad368a61b19b67d88117f7a8c29727bf71fffdeda81fbd946e/greenlet-3.5.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1072b4f9edcc1e192d9283a66a3e68d6b84c561de33a83d7858beb9ba1effe10", size = 614215, upload-time = "2026-05-20T14:05:42.675Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/6c/de5b1b388cd2d9fbdfeab324863daba37d54e6e233ddbefd70b385a8c591/greenlet-3.5.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:89101bfd5011e069be974903cb3a4e4523845e4ece2d62dcd8d358933c0ef249", size = 620094, upload-time = "2026-05-20T14:09:09.18Z" },
     { url = "https://files.pythonhosted.org/packages/40/69/b91cda0647df839483201545913514c2827ebea5e5ccdf931842763bc127/greenlet-3.5.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b", size = 611358, upload-time = "2026-05-20T13:14:26.37Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/43/1204baffab8a6476464795a7ccf394a3248d4f22c9f87173a15b36b6d971/greenlet-3.5.1-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:e6cd99ea59dd5d89f0c956606571d79bfe6f68c9eb7f4a4083a41a7f1587edee", size = 422782, upload-time = "2026-05-20T14:01:39.597Z" },
     { url = "https://files.pythonhosted.org/packages/59/90/3cf77e080350cd02fa307bb2abf05df48f4482c240275bbd2c203ba8bb1c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a5ea42a752d47a145eae922b605cd1634665ac3d5ec1e72402d5048e8d60d207", size = 1570475, upload-time = "2026-05-20T14:02:25.29Z" },
     { url = "https://files.pythonhosted.org/packages/65/2c/18cece62045e74598c3c393f70dce4a63f56222015ba29a5d4eeb04f764c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5551170cf4f5ff5623e9af81323751979fee2c731e2287b61f73cd27257b823", size = 1635625, upload-time = "2026-05-20T13:14:34.027Z" },
     { url = "https://files.pythonhosted.org/packages/30/f5/310d104ddf41eb5a70f4c268d22508dfb0c3c8e86fec152be34d0d2ed819/greenlet-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c8bb982ad117d29478ef8f5533e97df21f1e2befd17a299257b0c96d1371c0b", size = 238791, upload-time = "2026-05-20T13:10:39.018Z" },
@@ -409,9 +389,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/27/69/7f7e5372d998b81001899b1c0823c957aa413ba0f2662e65821611cc31e4/greenlet-3.5.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:51518ff74664078fc51bffcc6fc529b0df5ae58da192691cee765d45ce944a2b", size = 285060, upload-time = "2026-05-20T13:08:51.899Z" },
     { url = "https://files.pythonhosted.org/packages/b1/bf/387f9b6b865fd2ae0d0be09e0004827295a01b71be76ed350dd1e28a91a4/greenlet-3.5.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ffdb3c0bb002c99cd8f298957e046c3dbf6006b5b7cdf11a4e19194624a0a0a", size = 604370, upload-time = "2026-05-20T14:00:07.492Z" },
     { url = "https://files.pythonhosted.org/packages/32/f5/169ce3d4e4c67291bd18f8cbe0299c9f3e45102c7f1fb3c14780c93e4532/greenlet-3.5.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7715a5a2c3378ba602c3a440558261e13a820bb53a82693aacd7b7f6d964e283", size = 616987, upload-time = "2026-05-20T14:05:44.237Z" },
-    { url = "https://files.pythonhosted.org/packages/19/ba/c24110c55dffa55aa6e1d98b45310da33801aeba7686ff0190fe5d46fd32/greenlet-3.5.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d40a890035c0058cadbdc4af7569800fd28a0e527a0fdbb7b5f9418f176846ce", size = 622911, upload-time = "2026-05-20T14:09:10.598Z" },
     { url = "https://files.pythonhosted.org/packages/ee/e5/7f2e41d5273be07e77560d61ea4e56485b4d6c316d2a84518c62d1364061/greenlet-3.5.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc71ff466927a201b08305acac451ebe1aedfcea002f62f1f2f2ac2ac1e6a135", size = 613911, upload-time = "2026-05-20T13:14:27.539Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/7b/d20db2e8a5ad6c038702f3179b136f93f0a3d1a21a0c0777f3e470cdf4b2/greenlet-3.5.1-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:67821bb03e4e98664490edb787ff6af501194c29bbee0f5c1dfdcf1dc3d9d436", size = 425228, upload-time = "2026-05-20T14:01:40.837Z" },
     { url = "https://files.pythonhosted.org/packages/c5/a4/fbdc67579b73615a1f91615e814303cc71e06128f7baaba87be79b8fb90c/greenlet-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cd443683db272ebaaca03af98c0b063ab30db70ea8a31a1559f35e3f7b744ccd", size = 1570689, upload-time = "2026-05-20T14:02:27.225Z" },
     { url = "https://files.pythonhosted.org/packages/e6/b4/77abbe35078be39718a46cd49caf16bceb35662f97a34101dca28aa98e47/greenlet-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:089fff7a6ce8d9316d1f65ebc00273a56be258c1725b32b94de90a3a979557e1", size = 1635602, upload-time = "2026-05-20T13:14:36.344Z" },
     { url = "https://files.pythonhosted.org/packages/37/f7/129f27ca700845b8ee8ca88ce7f43435a1239c2eddb7677fc938822762cf/greenlet-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:110a1ca7b49b014b097f6078272c3f4ed31af45b254de5228b79adba879f6af9", size = 238683, upload-time = "2026-05-20T13:11:50.57Z" },
@@ -419,9 +397,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/cb/c62454606daf5640369c94d8a9dd540599b1bfc090e2d2180cb77f4038d2/greenlet-3.5.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8ab31c9de8651a2facdd5c5bb0011f2380dd1a7af78ce2adf4b56095294fc07", size = 285579, upload-time = "2026-05-20T13:08:56.396Z" },
     { url = "https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e300185139abc337ade480c327183adf42a875ac7181bfe66d7d4efea31fbea", size = 651106, upload-time = "2026-05-20T14:00:09.448Z" },
     { url = "https://files.pythonhosted.org/packages/1a/ab/71e34b78a44ec271fb5f550c17bc46d301ddc5953890d935f270b0dcdb5a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7ffdb990dcaa0234cf9845aead5df2e3c3a8b6507d409274dd87e0d5ab05ffc2", size = 663478, upload-time = "2026-05-20T14:05:45.88Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/2d/2d80842910da44f78c286532d084b8a5c3717c844ae80ceb3858738ae89a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c09df69dc1712d131332054a858a3e5cca400967fa3a672e2324fbb0971448c", size = 667767, upload-time = "2026-05-20T14:09:12.15Z" },
     { url = "https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2f82b3597e9d83b63408affed0b48fd0f54935edac4302237b9a837be0dae33c", size = 660800, upload-time = "2026-05-20T13:14:29.129Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/d3/dad2eecedfbb1ed7050a20dcfae40c1442b74bc7423608be2c7e03ee7133/greenlet-3.5.1-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:a4764e0bfc6a4d114c865b32520805c16a990ef5f286a514413b05d5ecd6a23d", size = 470786, upload-time = "2026-05-20T14:01:42.064Z" },
     { url = "https://files.pythonhosted.org/packages/7a/e0/6c71401a25cac7000261304e866a2f2cc04dc74810d40e2f118aa4799495/greenlet-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c0141e37414c10164e702b8fb1473304221ad98f71600850c6ef7ff4880feba0", size = 1617518, upload-time = "2026-05-20T14:02:28.662Z" },
     { url = "https://files.pythonhosted.org/packages/41/26/c5c06643e8c0af9e7bf18e16cb51d0ab7625155f0392e1c9015d66d556cd/greenlet-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:50ae25a67bea74ea41fb14b960bc532df73eb713417b2d61892dced82fe8d3bc", size = 1681593, upload-time = "2026-05-20T13:14:39.417Z" },
     { url = "https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:8a17c42330e261299766b75ac1ea32caa437a9453c8f65d16a13140db378ecd3", size = 239800, upload-time = "2026-05-20T13:09:30.128Z" },
@@ -429,18 +405,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/90/12/41bf27fde4d3605d3773ae57751eda182b8be2f5398011c041173b1d9534/greenlet-3.5.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:ea8da1e900d758d078810d4255d8c6aa572181896a31ec79d779eb79c3adc9ad", size = 293637, upload-time = "2026-05-20T13:12:35.529Z" },
     { url = "https://files.pythonhosted.org/packages/44/44/ba14b23e9757707050c2f397d305bbcae62e5d7cad122f8b6baec5ae4a1f/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a19570c52a21420dcbc94e661994bc325c0b5b11304540fed514586da5dc8f2e", size = 650840, upload-time = "2026-05-20T14:00:11.079Z" },
     { url = "https://files.pythonhosted.org/packages/a8/37/5ddc2b686a6844f91abecef43411842426da2e1573f60b49ecf2547f4ae1/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3d955c89b75eeca4723d7cc14135f393cd47c32e2a6cb4a8e4c6e760a26b0986", size = 656416, upload-time = "2026-05-20T14:05:47.118Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/46/5987dcd1a2570ba84f3b187536b2ca3ae97613387e57f5cfa99df068fe5e/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ea37d5a157eb9493820d3792ac4ece28619a394391d2b9f2f78057d396ff0f0f", size = 656607, upload-time = "2026-05-20T14:09:13.949Z" },
     { url = "https://files.pythonhosted.org/packages/e1/f0/d17510297c35a2992712f0bf84de3779749999f7d3d63aa1f09db7c62dbe/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2daaaebd1a5aa88c49045b6baf9310b3263796bd88db713edf37cf53e7bb4e", size = 654397, upload-time = "2026-05-20T13:14:30.696Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/c1/6da0a9ddcc29d7e51ef14883fa3dc1e53b3f4ffba00582106c7bf55da1d8/greenlet-3.5.1-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:8d8a23250ea3ec7b36de8fa4b541e9e2db3ee82915cc060ab0631609ad8b28de", size = 488287, upload-time = "2026-05-20T14:01:43.143Z" },
     { url = "https://files.pythonhosted.org/packages/37/eb/147387705bb89092645b012586e7273cb5ed3c90ef7eaf3a69173eaf0209/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bfbd69cc349e43bf3a8ae1c85548ff0718efc887615c2db16c3833d7b0b072d", size = 1614469, upload-time = "2026-05-20T14:02:30.192Z" },
     { url = "https://files.pythonhosted.org/packages/a6/4e/37ee0da7732b7aa9896f17e15579a9df34b9fcb9dd494f0adfa749af6623/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4378720dd888136c27215a0214d32a4d37c3852765d45bc37aad0623423cfd78", size = 1675115, upload-time = "2026-05-20T13:14:40.972Z" },
     { url = "https://files.pythonhosted.org/packages/57/f3/97dfcf4a6eb5077f8a672234216fb5923eb89f2cab7081cb10b2cf75b605/greenlet-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:45718441607f9325d948db98cbc691276059316d0358c188c246da4e1d4d23d2", size = 245246, upload-time = "2026-05-20T13:12:22.646Z" },
     { url = "https://files.pythonhosted.org/packages/5d/73/d7f72e34b582f694f4a9b248162db7b09cc458a259ba8f0c0bfa1a34ea7d/greenlet-3.5.1-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:2baee5ca02031757ffe8cc3d69f0cc0aec7065ce362622da74f32d3bcab1c541", size = 285575, upload-time = "2026-05-20T13:12:07.043Z" },
     { url = "https://files.pythonhosted.org/packages/df/59/fa9c6e87dc8ad27a95dabe2f29f372b733d05a8a67470f6c901ed9975655/greenlet-3.5.1-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b1ec3274918a81d3ea778b9e75b56b72b33f300edb6cf7f3a7fe1dae56683de", size = 656428, upload-time = "2026-05-20T14:00:12.556Z" },
     { url = "https://files.pythonhosted.org/packages/f6/f9/e753408871eaa61dfe35e619cfc67512b036fde99893685d50eea9e07146/greenlet-3.5.1-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:111e2390ffffc47d5840b01711dd7fac07d4c09283d0283e7f3264b14e284c64", size = 667064, upload-time = "2026-05-20T14:05:48.662Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/74/807a047255bf1e09303627c46dc043dca596b6958a354d904f32ab382005/greenlet-3.5.1-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:10a9a1c0bfbc93d41156ffcb90c75fbc05544054faf15dcc1fdf9765f8b607f0", size = 672962, upload-time = "2026-05-20T14:09:15.532Z" },
     { url = "https://files.pythonhosted.org/packages/96/27/5565b5b40389f1c7753003a07e21892fda8660926787036d5bc0308b8113/greenlet-3.5.1-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e630136e905fe5ff43e86945ae41220b6d1470956a39220e708110ac48d01ea5", size = 665697, upload-time = "2026-05-20T13:14:32.943Z" },
-    { url = "https://files.pythonhosted.org/packages/76/32/19d4e13225193c29b13e308015223f7d75fd3d8623d49dd19040d2ce8ec1/greenlet-3.5.1-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:ef08c1567c78074b22d1a200183d52d04a14df447bf70bcbb6a3507a48e776fc", size = 476047, upload-time = "2026-05-20T14:01:44.39Z" },
     { url = "https://files.pythonhosted.org/packages/cf/82/e7de4178c0c2d1c9a5a3be3cc0b33e46a85b3ee4a77c071bf7ad8600e079/greenlet-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:975eac34b44a7077ca4d421348455b94f0f518246a7f14bc6d2fdcfe5b584368", size = 1621256, upload-time = "2026-05-20T14:02:31.91Z" },
     { url = "https://files.pythonhosted.org/packages/00/10/f2dddcf7dacac17dfc68691809589adad06135eb28930429cf58a6467a2f/greenlet-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:9ab3c3a0b2ae6198e67c898dad5215a49f9ae0d0081b3c3ec59f333e39eeca26", size = 1685956, upload-time = "2026-05-20T13:14:42.55Z" },
     { url = "https://files.pythonhosted.org/packages/22/17/4a232b32133230ada52f70e9d7f5b65b0caef8772f01849bd8d149e7e4ca/greenlet-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:cbfc69be86e10dcfef5b1e6269d1d6926552aa89ee39e1de3353360c1b6989ab", size = 239802, upload-time = "2026-05-20T13:13:15.481Z" },
@@ -448,9 +420,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/57/816d9cff29119da3505b3d6a5e14a8af89006ac36f47f891ff293ee05af1/greenlet-3.5.1-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:a6fdf2433a5441ef9a95464f7c3e674775da1c8c1177fff311cee1acad4626ed", size = 293877, upload-time = "2026-05-20T13:10:19.078Z" },
     { url = "https://files.pythonhosted.org/packages/23/a1/59b0a7c7d140ff1a75626680b9a9899b79a9176cab298b394968fb023295/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7546556f0d649f99f6a361098a55f761181bb2ea12ff150bb16d26092ad88244", size = 655333, upload-time = "2026-05-20T14:00:14.758Z" },
     { url = "https://files.pythonhosted.org/packages/72/1b/5efe127597625042218939d01855109f352779050768b670b52edcc16a6c/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5ee3ea898009fa898f85f9982255d35278c477bebe185beca249cab42d4526c", size = 659443, upload-time = "2026-05-20T14:05:50.159Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/9d/1dcdf7b95ab3cf8c7b6d7277c18a5e167312f2b362ddfcc5d5e6d8d84b43/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a57b0d05a0448eed231d59c0ceb287dde984551e54cbc51ac2d4865712838e9c", size = 659998, upload-time = "2026-05-20T14:09:16.912Z" },
     { url = "https://files.pythonhosted.org/packages/6c/6d/c404246ea4d22d097a7426d0efb5b781bd7eb67715f09e79001bd552ab18/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5c81f74d204d3edd136ebfd50dce53acbb776995d721a0fe801626cfc93b8cd", size = 658356, upload-time = "2026-05-20T13:14:35.091Z" },
-    { url = "https://files.pythonhosted.org/packages/05/7e/c4959664fc231d587d66d8e81f2095e98056ba1954beafdcbe635e251052/greenlet-3.5.1-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:b0703c2cef53e01baec47f7a3868009913ad71ec678bbecb42a6f40895e4ce62", size = 494470, upload-time = "2026-05-20T14:01:45.611Z" },
     { url = "https://files.pythonhosted.org/packages/51/02/f8ee37fb6d2219329f350af241c27fcf12df57e723d11f6fc6d3bacdadaa/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:2c18ef16bf6d4dd410e4dd52996888ea1497be26892fe5bbc73580aba4287b8e", size = 1619216, upload-time = "2026-05-20T14:02:33.403Z" },
     { url = "https://files.pythonhosted.org/packages/93/c5/3dc9475ace2c7a3680da12372cddd7f1ac874eb410a1ac48d3e9dab83782/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:17d86354f0ae6b61bf9be5148d0dd34e06c3cb7c602c671f79f29ac3b150e659", size = 1678427, upload-time = "2026-05-20T13:14:43.71Z" },
     { url = "https://files.pythonhosted.org/packages/df/4e/750c15c317a41ffb36f0bf40b933e3d744a7dede61889f74443ea69690cf/greenlet-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:e7516cf6ae6b8a582c2770a0caed47b8a48373ed732c33d69a72913ae6ac923e", size = 245225, upload-time = "2026-05-20T13:13:59.366Z" },
@@ -473,15 +443,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
-]
-
-[[package]]
-name = "imagesize"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
 ]
 
 [[package]]
@@ -721,18 +682,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mdit-py-plugins"
-version = "0.6.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
-]
-
-[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -935,23 +884,6 @@ wheels = [
 ]
 
 [[package]]
-name = "myst-parser"
-version = "5.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "docutils" },
-    { name = "jinja2" },
-    { name = "markdown-it-py" },
-    { name = "mdit-py-plugins" },
-    { name = "pyyaml" },
-    { name = "sphinx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/dc/603751677fff302f34396e206b610f556a59d7fe58b9a2145f54e96b48e8/myst_parser-5.1.0.tar.gz", hash = "sha256:ab69322dc6719dcc7f296479dbb70181b66df6ed315064f92dbc85c0e1bf2f02", size = 101182, upload-time = "2026-05-13T09:38:19.361Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/dc/f3dfb7488b770f3f67e6545085bf2abea5172e88f57b8ad25ef860ca704c/myst_parser-5.1.0-py3-none-any.whl", hash = "sha256:9c91c52b3cdb4d94a6506e4fab4e2f296c7623a0da0dcbe6de1565c3dad67a8a", size = 85817, upload-time = "2026-05-13T09:38:17.904Z" },
-]
-
-[[package]]
 name = "numpy"
 version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1048,7 +980,6 @@ postgres = [
 
 [[package]]
 name = "omop-alchemy"
-version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "oa-configurator" },
@@ -1067,16 +998,12 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocs-mermaid2-plugin" },
     { name = "mkdocstrings-python" },
-    { name = "mypy" },
     { name = "oa-configurator", extra = ["dev", "postgres"] },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "requests" },
     { name = "ruff" },
-]
-docs = [
-    { name = "myst-parser" },
-    { name = "sphinx" },
+    { name = "ty" },
 ]
 postgres = [
     { name = "psycopg", extra = ["binary"] },
@@ -1089,8 +1016,6 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.7.1" },
     { name = "mkdocs-mermaid2-plugin", marker = "extra == 'dev'" },
     { name = "mkdocstrings-python", marker = "extra == 'dev'", specifier = ">=2.0.1" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
-    { name = "myst-parser", marker = "extra == 'docs'" },
     { name = "oa-configurator", specifier = "==0.1.2" },
     { name = "oa-configurator", extras = ["dev", "postgres"], marker = "extra == 'dev'", specifier = "==0.1.2" },
     { name = "orm-loader", specifier = "==0.5.1" },
@@ -1102,11 +1027,11 @@ requires-dist = [
     { name = "requests", marker = "extra == 'dev'", specifier = ">=2.33.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
-    { name = "sphinx", marker = "extra == 'docs'" },
     { name = "sqlalchemy", specifier = ">=2.0.45" },
+    { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.61" },
     { name = "typer", specifier = ">=0.12" },
 ]
-provides-extras = ["postgres", "dev", "docs"]
+provides-extras = ["dev", "postgres"]
 
 [[package]]
 name = "orm-loader"
@@ -1217,7 +1142,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1642,15 +1567,6 @@ wheels = [
 ]
 
 [[package]]
-name = "roman-numerals"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.15.14"
 source = { registry = "https://pypi.org/simple" }
@@ -1703,103 +1619,12 @@ wheels = [
 ]
 
 [[package]]
-name = "snowballstemmer"
-version = "3.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/ee/67eef9600338e245ad7838230969a34c823ddbdbccc5e1fc43cd75b55bc9/snowballstemmer-3.1.0.tar.gz", hash = "sha256:fd9e34526b23340cd23ffea6c9f9760974ecc2c2ac9e1d81401443ccdb2a801f", size = 122523, upload-time = "2026-05-24T19:04:19.691Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/83/ddbf4533c62dd32667ef1238952abef155f3d3391f5be69a352ad1638a42/snowballstemmer-3.1.0-py3-none-any.whl", hash = "sha256:17e6d1da216aa07db6dad37139ea70cf13c4b2e9a096f6e64a9648fc657d3154", size = 104550, upload-time = "2026-05-24T19:04:18.026Z" },
-]
-
-[[package]]
 name = "soupsieve"
 version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
-]
-
-[[package]]
-name = "sphinx"
-version = "9.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl", hash = "sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978", size = 3921742, upload-time = "2025-12-31T15:09:25.561Z" },
-]
-
-[[package]]
-name = "sphinxcontrib-applehelp"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/6e/b837e84a1a704953c62ef8776d45c3e8d759876b4a84fe14eba2859106fe/sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1", size = 20053, upload-time = "2024-07-29T01:09:00.465Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5", size = 119300, upload-time = "2024-07-29T01:08:58.99Z" },
-]
-
-[[package]]
-name = "sphinxcontrib-devhelp"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/d2/5beee64d3e4e747f316bae86b55943f51e82bb86ecd325883ef65741e7da/sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad", size = 12967, upload-time = "2024-07-29T01:09:23.417Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2", size = 82530, upload-time = "2024-07-29T01:09:21.945Z" },
-]
-
-[[package]]
-name = "sphinxcontrib-htmlhelp"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
-]
-
-[[package]]
-name = "sphinxcontrib-jsmath"
-version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
-]
-
-[[package]]
-name = "sphinxcontrib-qthelp"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/68/bc/9104308fc285eb3e0b31b67688235db556cd5b0ef31d96f30e45f2e51cae/sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab", size = 17165, upload-time = "2024-07-29T01:09:56.435Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb", size = 88743, upload-time = "2024-07-29T01:09:54.885Z" },
-]
-
-[[package]]
-name = "sphinxcontrib-serializinghtml"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
 ]
 
 [[package]]
@@ -1873,6 +1698,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/22/40f55b26baeab80c2d7b3f1db0682f8954e4617fee7d90ce634022ef05c6/traitlets-5.15.0.tar.gz", hash = "sha256:4fead733f81cf1c4c938e06f8ca4633896833c9d89eff878159457f4d4392971", size = 163197, upload-time = "2026-05-06T08:05:58.016Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/98/a9937a969d018a23badfea0b381f66783649d48e0ea6c41923265c3cbeb3/traitlets-5.15.0-py3-none-any.whl", hash = "sha256:fb36a18867a6803deab09f3c5e0fa81bb7b26a5c9e82501c9933f759166eff40", size = 85877, upload-time = "2026-05-06T08:05:55.853Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.61"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/63/6944925d0fe9a4bb9cc744e6c045a42bbd2ee4654c103190674577a36c3f/ty-0.0.61.tar.gz", hash = "sha256:acbf0d914cc7e2e57ccc440036af36114819e2a604a5ffb554e72e4ca7dd65a2", size = 6234957, upload-time = "2026-07-18T01:39:54.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/cf/044f31523e2768e3e64b0ca2ec32f70b3a731d4a2caa6ea110baf26e251c/ty-0.0.61-py3-none-linux_armv6l.whl", hash = "sha256:148779b8675eac93f40ec58bd70037fe67537117f20a23272264f8f136d41336", size = 11891448, upload-time = "2026-07-18T01:39:18.449Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/55/558cfe76b65d91d1854bbfac336020bd42fd887caa632d845d13c0c539eb/ty-0.0.61-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:08217382b3385808ee7288501ea3214b32631b08d1fd091ece6799b0c95264c5", size = 11602442, upload-time = "2026-07-18T01:39:20.914Z" },
+    { url = "https://files.pythonhosted.org/packages/27/be/78c0ae6634cd606a68e5b46b338db427a48a1800c96a749b2d2f7a702e03/ty-0.0.61-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6d99c729011b47dec20e78a32ac9c8f6defd4cf62f7bb851bbccf70dde6cee50", size = 11125286, upload-time = "2026-07-18T01:39:22.893Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/18/a40793962f1b6337938ddb0bca7496b54e70879e23b4d2cc8dfd7e5d1af3/ty-0.0.61-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cda607978ae271b77e51c947663218bce635c3507e256865444b10c37cdb60d", size = 11663403, upload-time = "2026-07-18T01:39:25.017Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c1/7879244da5b30407dc368946d36be5024380073408b079f144ffe034030e/ty-0.0.61-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0d78f160a0f9434d570cdcdbc4dafba1f6aac3c47a32f9f63995b3cb55ffe4b6", size = 11715250, upload-time = "2026-07-18T01:39:27.045Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/8a4637cd58abd37f315dd515e24c582986cb1bfdf2edc4786882f5a4f69a/ty-0.0.61-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09aeab4800b36e93e4ce918699004da642d74988cac920b7592a6a2b9be6611c", size = 12393876, upload-time = "2026-07-18T01:39:29.197Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4b/27e7c640b1272743503229aa17ae2167a538040c4716a2fa1777c2b34fea/ty-0.0.61-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dccc8136df44142a109953a168be17b4915c99876b047d0b6672c31dae939bdf", size = 12958187, upload-time = "2026-07-18T01:39:31.308Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/f5/70eaaefb6081fb0a8115cff66fbfaa20dafac8c646df2477adad95a59de2/ty-0.0.61-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:220760c2d13a887d027ee1093172c24ac35b6e634805329c93a30908ae4d3f5c", size = 12560101, upload-time = "2026-07-18T01:39:33.35Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/5a/17bae3b6429b5c479dc6c1e344d34e1f79efbc27531f15f3ee5b5da63745/ty-0.0.61-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:effefbb89da7128d18059529d1c2ea390fe7f1f3882690d257ca2143d49a0c34", size = 12225389, upload-time = "2026-07-18T01:39:35.436Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0e/2ac380ba20d6395542c8df1d6fa4f00e2aead784c2e6aaefa1e02ed0610c/ty-0.0.61-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:ba8b28a5ef811d5bb6461e37d76110c06fd20487474865c323d3d18b08b972b2", size = 12548403, upload-time = "2026-07-18T01:39:37.556Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/e5/7da4b73e825e1a9808c26d68b0156e9a37aede1846191210dfffb8c64042/ty-0.0.61-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:88ecd6d9b05e8174b1860dac9bd3e188d6cef5702b0d3239fd9f94f6ac73a29d", size = 11621813, upload-time = "2026-07-18T01:39:39.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3c/5b58015e998cd0d89b17a463b6321421457d86d987574e8dac65ddfceba3/ty-0.0.61-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:fb0cdfe4c48542ffb9a1139825dfa3d4aae49e96e966682ef7da762ab97831ff", size = 11734101, upload-time = "2026-07-18T01:39:42.097Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/21/294f4cc819b7b12ed659fd860e5cdfbd592d4c768c8f23596685dbc43e6b/ty-0.0.61-py3-none-musllinux_1_2_i686.whl", hash = "sha256:dff03873c0c3d0b44738f8b6d403b0756a31cf54c65136397df7624c6159b1f0", size = 11988401, upload-time = "2026-07-18T01:39:44.183Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/26/0f96f79fdac118521a9771e9eef3f9b3f447d647b2c77953e80a1715c7e8/ty-0.0.61-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a9210e80e3d41c1dfc751e9e8e0980272f475031fafd0fb0f48aee233c78da03", size = 12330624, upload-time = "2026-07-18T01:39:46.662Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/08/1e62d1bca5c0cebdc7a34db1f4b61557aab85961cedd56953dd2c32d3e66/ty-0.0.61-py3-none-win32.whl", hash = "sha256:e3e1fe06f49a5492a922a5df2739834aa5ee978c7dd10414119dc8755cc40c9c", size = 11313991, upload-time = "2026-07-18T01:39:48.761Z" },
+    { url = "https://files.pythonhosted.org/packages/26/f1/d8e33b3aeb36b73d81ae34d10e46ec4abf506d68f4e0a1491a76a593dd42/ty-0.0.61-py3-none-win_amd64.whl", hash = "sha256:25f2291169e0298fcdbba1b1fea64f8207a6c1908dddef32346fd5e3e6ac9221", size = 12311717, upload-time = "2026-07-18T01:39:50.881Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/14/7caec26d93a943c0e7d15eb7374644508d08cbd387d112b722b12d14e044/ty-0.0.61-py3-none-win_arm64.whl", hash = "sha256:3e496f7698bc4b5bbb1eb66d8b5799ba87596d88d36604ca359083893fa2fc49", size = 11693485, upload-time = "2026-07-18T01:39:52.73Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`collect_doctor_report()` was calling `get_cdm_context()` a second time even though `collect_maintenance_info()` (called immediately before it) already resolves the same config. This results in  three independent config reads for one `doctor` CLI invocation once the `@omop_command` decorator's own resolution is counted.

Now threads the already-resolved result through instead of re-reading. `collect_maintenance_info()`'s own independent resolution is intentionally left as-is (it's a diagnostic health-check whose job is to test config resolution fresh, not a case of "caller already has it") . Its broad `except Exception` around that resolution is narrowed to avoid mislabeling unrelated bugs as a generic engine-resolution error.
