### PR TITLE
flag handling uniformity

### DIFF
--- a/omop_alchemy/cdm/model/__init__.py
+++ b/omop_alchemy/cdm/model/__init__.py
@@ -7,7 +7,14 @@ from .health_economic import Cost, Payer_Plan_Period
 from .structural import Episode, Episode_Event, Fact_Relationship
 from .unstructured import Note, Note_NLP
 from .metadata import CDM_Source, Metadata
-
+from .flags import (
+    InvalidReasonMixin,
+    InvalidReasonFlag,
+    StandardConceptFlag,
+    normalised_flag_expr,
+    normalised_flag,
+    BooleanFlag
+)
 from .typing import ConceptRow
 
 __all__ = [
@@ -47,4 +54,10 @@ __all__ = [
     "CDM_Source",
     "Metadata",
     "ConceptRow",
+    "InvalidReasonFlag",
+    "InvalidReasonMixin",
+    "BooleanFlag",
+    "normalised_flag",
+    "StandardConceptFlag",
+    "normalised_flag_expr",
 ]

--- a/omop_alchemy/cdm/model/flags.py
+++ b/omop_alchemy/cdm/model/flags.py
@@ -1,0 +1,68 @@
+from enum import StrEnum, nonmember
+import sqlalchemy as sa
+import sqlalchemy.orm as so
+from typing import Optional
+
+class StandardConceptFlag(StrEnum):
+    """Allowed non-null values of ``concept.standard_concept`` (OMOP CDM v5.4)."""
+
+    STANDARD = "S"
+    CLASSIFICATION = "C"
+
+    # Keep the complete allowed-value set available to callers that need to
+    # validate the column independently of the standard/classification split.
+    values = nonmember(frozenset({STANDARD, CLASSIFICATION}))
+
+class InvalidReasonFlag(StrEnum):
+    """Allowed non-null values of ``concept.invalid_reason`` (OMOP CDM v5.4)."""
+
+    DELETED = "D"
+    UPDATED = "U"
+
+class BooleanFlag(StrEnum):
+    """Allowed non-null values of ``relationship.is_hierarchical`` and 
+    ``relationship.defines_ancestry`` (OMOP CDM v5.4)."""
+    TRUE = "1"
+    FALSE = "0"
+
+def normalised_flag_expr(
+    column: sa.SQLColumnExpression[Optional[str]],
+) -> sa.SQLColumnExpression[Optional[str]]:
+    """Return a canonical OMOP flag expression.
+
+    OMOP CDM v5.4 allows only ``NULL``/``'S'``/``'C'`` for ``standard_concept``
+    and ``NULL``/``'D'``/``'U'`` for ``invalid_reason``. Some real-world loads
+    contain blank or whitespace-only strings instead of ``NULL``; those are
+    normalised here defensively so callers do not need to reimplement the same
+    tolerance logic.
+
+    Non-empty non-canonical values are left unchanged so downstream validation
+    can still detect them as bad data rather than silently treating them as a
+    valid state.
+    """
+    return sa.func.nullif(sa.func.trim(column), "")
+
+def normalised_flag(value: str | None) -> str | None:
+    """Python counterpart to :func:`normalised_flag_expr`.
+
+    Blank and whitespace-only strings normalise to ``None``; non-empty
+    non-canonical values are returned unchanged so callers can still detect
+    them as bad data.
+    """
+    if value is None:
+        return None
+    return value.strip() or None
+
+
+class InvalidReasonMixin:
+    invalid_reason: so.Mapped[Optional[str]] = so.mapped_column(sa.String(1), nullable=True)
+
+    @property
+    def is_valid(self) -> bool:
+        """True when ``invalid_reason`` is unset (NULL, blank, or whitespace-only)."""
+        return normalised_flag(self.invalid_reason) is None
+
+    @classmethod
+    def is_valid_expr(cls) -> sa.SQLColumnExpression[bool]:
+        """SQL-side counterpart to :attr:`is_valid`."""
+        return normalised_flag_expr(cls.invalid_reason).is_(None)

--- a/omop_alchemy/cdm/model/vocabulary/__init__.py
+++ b/omop_alchemy/cdm/model/vocabulary/__init__.py
@@ -3,10 +3,7 @@ from .concept_class import Concept_Class
 from .concept import (
     Concept,
     ConceptContext,
-    ConceptView,
-    InvalidReasonFlag,
-    StandardConceptFlag,
-    normalised_flag_expr,
+    ConceptView
 )
 from .concept_relationship import Concept_Relationship
 from .domain import Domain
@@ -22,9 +19,6 @@ __all__ = [
     "Concept",
     "ConceptContext",
     "ConceptView",
-    "InvalidReasonFlag",
-    "StandardConceptFlag",
-    "normalised_flag_expr",
     "Concept_Relationship",
     "Domain",
     "Relationship",

--- a/omop_alchemy/cdm/model/vocabulary/concept.py
+++ b/omop_alchemy/cdm/model/vocabulary/concept.py
@@ -1,7 +1,6 @@
 import sqlalchemy as sa
 import sqlalchemy.orm as so
 from sqlalchemy.ext.declarative import declared_attr
-from enum import StrEnum, nonmember
 from typing import Optional, TYPE_CHECKING, List
 from datetime import date
 if TYPE_CHECKING:
@@ -22,48 +21,18 @@ from omop_alchemy.cdm.base import (
     omop_primary_key_index_name,
     omop_table_options,
 )
-
-
-class StandardConceptFlag(StrEnum):
-    """Allowed non-null values of ``concept.standard_concept`` (OMOP CDM v5.4)."""
-
-    STANDARD = "S"
-    CLASSIFICATION = "C"
-
-    # Precomputed membership set for the hot Python-side check (Concept.is_standard) --
-    # re-deriving this from the enum on every call is measurably expensive (~10x).
-    values = nonmember(frozenset({STANDARD, CLASSIFICATION}))
-
-
-class InvalidReasonFlag(StrEnum):
-    """Allowed non-null values of ``concept.invalid_reason`` (OMOP CDM v5.4)."""
-
-    DELETED = "D"
-    UPDATED = "U"
-
-
-def normalised_flag_expr(
-    column: sa.SQLColumnExpression[Optional[str]],
-) -> sa.SQLColumnExpression[Optional[str]]:
-    """Return a canonical OMOP flag expression.
-
-    OMOP CDM v5.4 allows only ``NULL``/``'S'``/``'C'`` for ``standard_concept``
-    and ``NULL``/``'D'``/``'U'`` for ``invalid_reason``. Some real-world loads
-    contain blank or whitespace-only strings instead of ``NULL``; those are
-    normalised here defensively so callers do not need to reimplement the same
-    tolerance logic.
-
-    Non-empty non-canonical values are left unchanged so downstream validation
-    can still detect them as bad data rather than silently treating them as a
-    valid state.
-    """
-    return sa.func.nullif(sa.func.trim(column), "")
-
+from omop_alchemy.cdm.model.flags import (
+    StandardConceptFlag,
+    InvalidReasonMixin,
+    normalised_flag_expr,
+    normalised_flag,
+)
 
 @cdm_table
 class Concept(
     ReferenceTable,
     CDMTableBase,
+    InvalidReasonMixin,
     Base
 ):
     __tablename__ = "concept"
@@ -90,27 +59,42 @@ class Concept(
     concept_code: so.Mapped[str] = so.mapped_column(sa.String(50), nullable=False)
     valid_start_date: so.Mapped[date] = so.mapped_column(sa.Date(), nullable=False)
     valid_end_date: so.Mapped[date] = so.mapped_column(sa.Date(), nullable=False)
-    invalid_reason: so.Mapped[Optional[str]] = so.mapped_column(sa.String(1), nullable=True)
 
     @property
     def is_standard(self) -> bool:
-        value = self.standard_concept.strip() if self.standard_concept is not None else ""
-        return bool(value) and value in StandardConceptFlag.values
+        """True only for normalised OMOP ``standard_concept == 'S'``."""
+        return normalised_flag(self.standard_concept) == StandardConceptFlag.STANDARD
 
     @classmethod
     def is_standard_expr(cls) -> sa.SQLColumnExpression[bool]:
-        """SQL-side counterpart to :attr:`is_standard`, for use in query filters."""
-        return normalised_flag_expr(cls.standard_concept).in_(StandardConceptFlag.values)
+        """SQL-side counterpart to :attr:`is_standard`. 
+        
+        Note that we use this somewhat goofy expression here and in similarly 
+        constructed flag-derived filters so that we can ensure that this never 
+        evaluates to NULL, which is important for filtering in queries, being 
+        able to robustly `or_` it with other expressions, query negation etc. 
+        
+        The `coalesce` ensures that if the `standard_concept` is NULL, it will 
+        return `False` instead of NULL.
+        """
+        return sa.func.coalesce(
+            normalised_flag_expr(cls.standard_concept) == StandardConceptFlag.STANDARD.value,
+            sa.false(),
+        )
 
     @property
-    def is_valid(self) -> bool:
-        value = self.invalid_reason.strip() if self.invalid_reason is not None else ""
-        return not value
+    def is_classification(self) -> bool:
+        """True only for normalised OMOP ``standard_concept == 'C'`` — a classification
+        node, valid for hierarchy navigation but not as a mapping target."""
+        return normalised_flag(self.standard_concept) == StandardConceptFlag.CLASSIFICATION
 
     @classmethod
-    def is_valid_expr(cls) -> sa.SQLColumnExpression[bool]:
-        """SQL-side counterpart to :attr:`is_valid`, for use in query filters."""
-        return normalised_flag_expr(cls.invalid_reason).is_(None)
+    def is_classification_expr(cls) -> sa.SQLColumnExpression[bool]:
+        """SQL-side counterpart to :attr:`is_classification`."""
+        return sa.func.coalesce(
+            normalised_flag_expr(cls.standard_concept) == StandardConceptFlag.CLASSIFICATION.value,
+            sa.false(),
+        )
 
 class ConceptContext(ReferenceContext):
     """

--- a/omop_alchemy/cdm/model/vocabulary/concept_relationship.py
+++ b/omop_alchemy/cdm/model/vocabulary/concept_relationship.py
@@ -1,6 +1,5 @@
 import sqlalchemy as sa
 import sqlalchemy.orm as so
-from typing import Optional
 from datetime import date
 from orm_loader.helpers import Base
 from omop_alchemy.cdm.base import (

--- a/omop_alchemy/cdm/model/vocabulary/concept_relationship.py
+++ b/omop_alchemy/cdm/model/vocabulary/concept_relationship.py
@@ -10,9 +10,15 @@ from omop_alchemy.cdm.base import (
     merge_table_args,
     omop_index,
 )
+from omop_alchemy.cdm.model.flags import InvalidReasonMixin
 
 @cdm_table
-class Concept_Relationship(ReferenceTable, CDMTableBase, Base):
+class Concept_Relationship(
+    ReferenceTable, 
+    CDMTableBase, 
+    InvalidReasonMixin, 
+    Base
+    ):
     __tablename__ = "concept_relationship"
     __table_args__ = merge_table_args(
         omop_index(__tablename__, "concept_id_1", cluster=True),
@@ -24,4 +30,3 @@ class Concept_Relationship(ReferenceTable, CDMTableBase, Base):
     relationship_id: so.Mapped[str] = so.mapped_column(sa.ForeignKey("relationship.relationship_id"),primary_key=True)
     valid_start_date: so.Mapped[date] = so.mapped_column(nullable=False)
     valid_end_date: so.Mapped[date] = so.mapped_column(nullable=False)
-    invalid_reason: so.Mapped[Optional[str]] = so.mapped_column(sa.String(1), nullable=True)

--- a/omop_alchemy/cdm/model/vocabulary/drug_strength.py
+++ b/omop_alchemy/cdm/model/vocabulary/drug_strength.py
@@ -10,11 +10,13 @@ from omop_alchemy.cdm.base import (
     merge_table_args,
     omop_index,
 )
+from omop_alchemy.cdm.model.flags import InvalidReasonMixin
 
 @cdm_table
 class Drug_Strength(
     CDMTableBase,
     ReferenceTable,
+    InvalidReasonMixin,
     Base,
 ):
     """
@@ -40,4 +42,3 @@ class Drug_Strength(
     box_size: so.Mapped[Optional[int]] = so.mapped_column(sa.Integer, nullable=True)
     valid_start_date: so.Mapped[date] = so.mapped_column(nullable=False)
     valid_end_date: so.Mapped[date] = so.mapped_column(nullable=False)
-    invalid_reason: so.Mapped[Optional[str]] = so.mapped_column(sa.String(1), nullable=True)

--- a/omop_alchemy/cdm/model/vocabulary/relationship.py
+++ b/omop_alchemy/cdm/model/vocabulary/relationship.py
@@ -9,6 +9,7 @@ from omop_alchemy.cdm.base import (
     omop_primary_key_index_name,
     omop_table_options,
 )
+from omop_alchemy.cdm.model.flags import BooleanFlag, normalised_flag_expr, normalised_flag
 
 @cdm_table
 class Relationship(Base, ReferenceTable, CDMTableBase):
@@ -25,3 +26,26 @@ class Relationship(Base, ReferenceTable, CDMTableBase):
 
     def __repr__(self):
         return f"<Relationship {self.relationship_id}>"
+
+    @property
+    def is_hierarchical_relationship(self) -> bool:
+        """True only for normalised OMOP ``is_hierarchical == '1'``."""
+        return normalised_flag(self.is_hierarchical) == BooleanFlag.TRUE
+
+    @classmethod
+    def is_hierarchical_relationship_expr(cls) -> sa.SQLColumnExpression[bool]:
+        return sa.func.coalesce(
+            normalised_flag_expr(cls.is_hierarchical) == BooleanFlag.TRUE.value,
+            sa.false(),
+        )
+
+    @property
+    def is_ancestry_defining(self) -> bool:
+        return normalised_flag(self.defines_ancestry) == BooleanFlag.TRUE
+
+    @classmethod
+    def is_ancestry_defining_expr(cls) -> sa.SQLColumnExpression[bool]:
+        return sa.func.coalesce(
+            normalised_flag_expr(cls.defines_ancestry) == BooleanFlag.TRUE.value,
+            sa.false(),
+        )

--- a/omop_alchemy/cdm/model/vocabulary/source_to_concept_map.py
+++ b/omop_alchemy/cdm/model/vocabulary/source_to_concept_map.py
@@ -13,12 +13,14 @@ from omop_alchemy.cdm.base import (
     merge_table_args,
     omop_index,
 )
+from omop_alchemy.cdm.model.flags import InvalidReasonMixin
 
 @cdm_table
 class Source_To_Concept_Map(
     DatedEvent,
     CDMTableBase,
     ReferenceTable,
+    InvalidReasonMixin,
     Base,
 ):
     """
@@ -44,7 +46,6 @@ class Source_To_Concept_Map(
     target_vocabulary_id: so.Mapped[str] = so.mapped_column(sa.ForeignKey("vocabulary.vocabulary_id"),nullable=False)
     valid_start_date: so.Mapped[date] = so.mapped_column(nullable=False)
     valid_end_date: so.Mapped[date] = so.mapped_column(nullable=False)
-    invalid_reason: so.Mapped[Optional[str]] = so.mapped_column(sa.String(1), nullable=True)
 
     @classmethod
     def extra_validate(cls) -> list[ValidationIssue]:

--- a/omop_alchemy/cdm/query.py
+++ b/omop_alchemy/cdm/query.py
@@ -29,8 +29,12 @@ class ConceptFilter:
         Restrict results to concepts from these vocabularies.
     require_standard : bool
         When ``True``, only concepts where ``Concept.is_standard`` is
-        ``True`` are returned (``standard_concept`` in ``('S', 'C')``,
-        tolerating blank/whitespace-only values as unset). Default ``False``.
+        ``True`` are returned (``standard_concept == 'S'``, tolerating
+        surrounding whitespace). Classification concepts (``'C'``) are
+        excluded because they are not valid mapping targets. Default ``False``.
+    include_classification : bool
+        Only meaningful with ``require_standard``. When ``True``, classification
+        concepts (``'C'``) are admitted alongside standard ones. Default ``False``.
     require_active : bool
         When ``True``, only concepts where ``Concept.is_valid`` is ``True``
         are returned (``invalid_reason`` is ``NULL``/blank/whitespace, i.e.
@@ -44,6 +48,7 @@ class ConceptFilter:
     domains: Optional[tuple[str, ...]] = None
     vocabularies: Optional[tuple[str, ...]] = None
     require_standard: bool = False
+    include_classification: bool = False
     require_active: bool = False
     limit: Optional[int] = None
 
@@ -65,8 +70,14 @@ class ConceptFilter:
             query = query.where(Concept.vocabulary_id.in_(self.vocabularies))
 
         if self.require_standard:
-            query = query.where(Concept.is_standard_expr())
-
+            query = query.where(
+                sa.or_(
+                    Concept.is_standard_expr(),
+                    Concept.is_classification_expr(),
+                )
+                if self.include_classification
+                else Concept.is_standard_expr()
+            )
         if self.require_active:
             query = query.where(Concept.is_valid_expr())
 

--- a/omop_alchemy/toolkit/core/concepts/groups.py
+++ b/omop_alchemy/toolkit/core/concepts/groups.py
@@ -54,18 +54,24 @@ class ConceptGroupSpec:
     include_descendants
         Expand ``parent_ids`` through ``concept_ancestor``.  When False only
         the anchors themselves are members.
-    standard_only
-        Restrict expansion to standard concepts.  Defaults to False, matching
-        the historical oncology behaviour of reading ``concept_ancestor``
-        without a standard filter.  Note this is the *opposite* default to
-        ``OMOPConceptSource.descendants``; the difference is deliberate and
-        declared here rather than left implicit.
+    require_standard
+        Restrict expansion to concepts carrying a standardness flag.  Defaults to
+        False, matching the historical oncology behaviour of reading
+        ``concept_ancestor`` without a standard filter.  Note this is the
+        *opposite* default to ``OMOPConceptSource.descendants``; the difference is
+        deliberate and declared here rather than left implicit.
+    include_classification
+        Widens ``require_standard`` to admit classification ('C') concepts.
+        Defaults to True so a governed group can be anchored on a classification
+        node (ATC, for example) without silently losing it.  Has no effect unless
+        ``require_standard`` is set.
     """
 
     name: str
     unit: Any
     include_descendants: bool = True
-    standard_only: bool = False
+    require_standard: bool = False
+    include_classification: bool = True
 
     def parent_ids(self) -> tuple[int, ...]:
         """Governed descendant-expanding anchors."""
@@ -101,12 +107,20 @@ class ConceptGroupSpec:
 
         if parents and self.include_descendants:
             expr = column.in_(
-                _descendant_select(parents, standard_only=self.standard_only)
+                _descendant_select(
+                    parents,
+                    require_standard=self.require_standard,
+                    include_classification=self.include_classification,
+                )
             )
             excluded = self.excluded_parent_ids()
             if excluded:
                 expr = expr & column.not_in(
-                    _descendant_select(excluded, standard_only=self.standard_only)
+                    _descendant_select(
+                        excluded,
+                        require_standard=self.require_standard,
+                        include_classification=self.include_classification,
+                    )
                 )
             clauses.append(expr)
         elif parents:
@@ -123,18 +137,24 @@ class ConceptGroupSpec:
 def _descendant_select(
     parents: Iterable[int],
     *,
-    standard_only: bool,
+    require_standard: bool,
+    include_classification: bool = True,
 ) -> sa.Select:
     stmt = sa.select(Concept_Ancestor.descendant_concept_id).where(
         Concept_Ancestor.ancestor_concept_id.in_(tuple(parents))
     )
-    if standard_only:
+    if require_standard:
         from omop_alchemy.cdm.model.vocabulary import Concept
 
+        standardness = (
+            sa.or_(Concept.is_standard_expr(), Concept.is_classification_expr())
+            if include_classification
+            else Concept.is_standard_expr()
+        )
         stmt = stmt.join(
             Concept,
             Concept.concept_id == Concept_Ancestor.descendant_concept_id,
-        ).where(Concept.is_standard_expr())
+        ).where(standardness)
     return stmt
 
 
@@ -197,11 +217,19 @@ def build_concept_group(
 
     if parents:
         if spec.include_descendants:
-            stmt = _descendant_select(parents, standard_only=spec.standard_only)
+            stmt = _descendant_select(
+                parents,
+                require_standard=spec.require_standard,
+                include_classification=spec.include_classification,
+            )
             ids |= set(session.execute(stmt).scalars().all())
             excluded = spec.excluded_parent_ids()
             if excluded:
-                stmt = _descendant_select(excluded, standard_only=spec.standard_only)
+                stmt = _descendant_select(
+                    excluded,
+                    require_standard=spec.require_standard,
+                    include_classification=spec.include_classification,
+                )
                 ids -= set(session.execute(stmt).scalars().all())
         else:
             ids |= set(parents)

--- a/omop_alchemy/toolkit/core/concepts/lookup.py
+++ b/omop_alchemy/toolkit/core/concepts/lookup.py
@@ -7,11 +7,12 @@ import sqlalchemy.orm as so
 from .normalizers import normalize_default
 from omop_alchemy.cdm.model import ConceptRow
 from omop_alchemy.cdm.model.vocabulary import Concept, Concept_Synonym, Concept_Ancestor
+from omop_alchemy.cdm.query import ConceptFilter
 
 """
 Class definitions for vocabulary handling and mapping.
 
-This is somewhat redunant with some of omop-graph but 
+This is somewhat redundant with some of omop-graph but 
 mutual dependency is awkward and this is a thin layer so 
 it's not worth over-engineering separation at this stage.
 """
@@ -101,8 +102,19 @@ class LookupSpec:
         Optional list of OMOP concept_class_id values to restrict the lookup
     vocabulary_id:
         Optional list of OMOP vocabulary_id values to restrict the lookup
-    standard_only:
-        If True, restricts the lookup to standard concepts only.
+    require_standard:
+        If True, restricts the lookup to concepts carrying a standardness flag.
+        Named to match ``ConceptFilter.require_standard``, which it delegates to.
+    include_classification:
+        Widens ``require_standard`` to admit classification ('C') concepts.
+        Defaults to True: a lookup exists to *recognise* vocabulary terms, and a
+        classification concept is a legitimate thing to recognise even though it
+        is not a valid mapping target. Set False for selection-shaped lookups.
+    require_active:
+        If True, excludes concepts with an ``invalid_reason``. Defaults to False
+        so recognition stays permissive — a deprecated concept that matches the
+        text can still be resolved forward through "Maps to" / "Concept replaced
+        by", whereas filtering it out here discards the term entirely.
     code_filter:
         Optional substring filter applied to concept_code (ILIKE-based).
         Useful for coarse scoping (e.g. AJCC-only codes).
@@ -137,7 +149,9 @@ class LookupSpec:
     domain_id: str | None = None
     concept_class_id: list[str] | None = None
     vocabulary_id: list[str] | None = None
-    standard_only: bool = True
+    require_standard: bool = True
+    include_classification: bool = True
+    require_active: bool = False
     code_filter: str | None = None
     parents: list[int] | None = None
     include_non_standard_descendants: bool = False
@@ -160,19 +174,29 @@ class OMOPConceptSource:
     """
 
     @staticmethod
-    def fetch_synonyms(session: so.Session) -> list[tuple[int, str]]:
+    def fetch_synonyms(
+        session: so.Session,
+        *,
+        concept_ids: Iterable[int] | None = None,
+    ) -> list[tuple[int, str]]:
         """
-        Return (concept_id, synonym) pairs for all concept synonyms.
+        Return (concept_id, synonym) pairs for concept synonyms.
 
-        Filtering (standard / domain / etc.) is intentionally left
-        to higher layers.
+        The join to ``concept`` scopes the result to synonyms whose concept
+        actually exists, and *concept_ids* narrows it further to a caller-supplied
+        set. Both are applied in SQL: without them this streams every synonym row
+        in the vocabulary back to Python to be discarded, which on a full Athena
+        load is millions of rows for a lookup covering a handful of domains.
         """
-        rows = session.execute(
-            sa.select(
-                Concept_Synonym.concept_id,
-                Concept_Synonym.concept_synonym_name,
-            )
-        ).all()
+        query = sa.select(
+            Concept_Synonym.concept_id,
+            Concept_Synonym.concept_synonym_name,
+        ).join(Concept, Concept.concept_id == Concept_Synonym.concept_id)
+
+        if concept_ids is not None:
+            query = query.where(Concept_Synonym.concept_id.in_(list(concept_ids)))
+
+        rows = session.execute(query).all()
 
         return [
             (int(r.concept_id), r.concept_synonym_name)
@@ -187,7 +211,9 @@ class OMOPConceptSource:
         domain_id: str | None = None,
         concept_class_id: Iterable[str] | None = None,
         vocabulary_id: Iterable[str] | None = None,
-        standard_only: bool = True,
+        require_standard: bool = True,
+        include_classification: bool = True,
+        require_active: bool = False,
         code_filter: str | None = None,
         parents: Iterable[int] | None = None,
         include_non_standard_descendants: bool = False,
@@ -199,31 +225,59 @@ class OMOPConceptSource:
         1. Flat filtering by domain / class / vocabulary
         2. Hierarchical expansion from parent concept(s)
 
+        Domain, vocabulary, standardness and validity are delegated to
+        :class:`~omop_alchemy.cdm.query.ConceptFilter` so this layer shares one
+        implementation of the OMOP flag rules with the rest of the package. In
+        particular the flag comparisons are normalised, so a blank or
+        whitespace-padded ``standard_concept`` is classified the same way here as
+        it is by ``Concept.is_standard``.
+
+        Recognition is permissive by default, because this layer resolves *text
+        to a concept*, not a concept to a mapping target. Both defaults follow
+        from that:
+
+        - *include_classification* is ``True`` — classification concepts are
+          legitimate things to recognise, even though they are not valid mapping
+          targets.
+        - *require_active* is ``False`` — a deprecated concept that matches the
+          text is a useful hit, because the caller can follow ``Maps to`` /
+          ``Concept replaced by`` to a valid successor. Filtering it out at
+          recognition time discards the term entirely, with nothing to resolve
+          forward from.
+
+        Pass ``include_classification=False`` / ``require_active=True`` when the
+        index feeds concept *selection* rather than recognition, where the strict
+        OMOP mapping-target rules apply.
         """
 
-        q = session.query(Concept)
+        parents = list(parents) if parents else None
+        # Standardness is dropped only for an explicitly non-standard descendant
+        # expansion; every other combination keeps it.
+        apply_standard = require_standard and not (
+            parents and include_non_standard_descendants
+        )
+
+        query = sa.select(Concept)
         if parents:
-            parents = list(parents)
-            q = (
-                q.join(
-                    Concept_Ancestor,
-                    Concept_Ancestor.descendant_concept_id == Concept.concept_id,
-                )
-                .filter(Concept_Ancestor.ancestor_concept_id.in_(parents))
-            )
-            if standard_only and not include_non_standard_descendants:
-                q = q.filter(Concept.standard_concept == "S")
-        if domain_id:
-            q = q.filter(Concept.domain_id == domain_id)
+            query = query.join(
+                Concept_Ancestor,
+                Concept_Ancestor.descendant_concept_id == Concept.concept_id,
+            ).where(Concept_Ancestor.ancestor_concept_id.in_(parents))
+
+        query = ConceptFilter(
+            domains=(domain_id,) if domain_id else None,
+            vocabularies=tuple(vocabulary_id) if vocabulary_id else None,
+            require_standard=apply_standard,
+            include_classification=include_classification,
+            require_active=require_active,
+        ).apply(query)
+
         if concept_class_id:
-            q = q.filter(Concept.concept_class_id.in_(list(concept_class_id)))
-        if vocabulary_id:
-            q = q.filter(Concept.vocabulary_id.in_(list(vocabulary_id)))
-        if standard_only and not parents:
-            q = q.filter(Concept.standard_concept == "S")
+            query = query.where(Concept.concept_class_id.in_(list(concept_class_id)))
         if code_filter:
-            q = q.filter(Concept.concept_code.ilike(f"%{code_filter}%"))
-        rows = q.all()
+            query = query.where(Concept.concept_code.ilike(f"%{code_filter}%"))
+
+        rows = session.execute(query).scalars().all()
         return [
             ConceptRow(
                 concept_id=int(r.concept_id),
@@ -248,7 +302,7 @@ class OMOPConceptSource:
             session,
             parents=parents,
             include_non_standard_descendants=include_non_standard,
-            standard_only=not include_non_standard,
+            require_standard=not include_non_standard,
         )
         return list({r.concept_id for r in rows})
     
@@ -263,7 +317,9 @@ class OMOPConceptSource:
             domain_id=spec.domain_id,
             concept_class_id=spec.concept_class_id,
             vocabulary_id=spec.vocabulary_id,
-            standard_only=spec.standard_only,
+            require_standard=spec.require_standard,
+            include_classification=spec.include_classification,
+            require_active=spec.require_active,
             code_filter=spec.code_filter,
             parents=spec.parents,
             include_non_standard_descendants=spec.include_non_standard_descendants,
@@ -279,8 +335,10 @@ class OMOPConceptSource:
                 m[spec.normalizer(r.concept_code)] = r.concept_id
 
         if spec.include_synonyms:
-            for cid, syn in OMOPConceptSource.fetch_synonyms(session):
-                if cid in ids and syn:
+            for cid, syn in OMOPConceptSource.fetch_synonyms(
+                session, concept_ids=ids
+            ):
+                if syn:
                     m[spec.normalizer(syn)] = cid
 
         return LookupIndex(name=spec.name, unknown=spec.unknown, mapping=m)
@@ -417,7 +475,9 @@ def make_concept_resolver(
     domain_id: str | None = None,
     concept_class_id: list[str] | None = None,
     vocabulary_id: list[str] | None = None,
-    standard_only: bool = True,
+    require_standard: bool = True,
+    include_classification: bool = True,
+    require_active: bool = False,
     code_filter: str | None = None,
     parents: list[int] | None = None,
     include_non_standard_descendants: bool = False,
@@ -450,8 +510,19 @@ def make_concept_resolver(
         Optional list of OMOP concept_class_id values to restrict the lookup.
     vocabulary_id:
         Optional list of OMOP vocabulary_id values to restrict the lookup.
-    standard_only:
-        If True, restricts the lookup to standard concepts only.
+    require_standard:
+        If True, restricts the lookup to concepts carrying a standardness flag.
+        Named to match ``ConceptFilter.require_standard``, which it delegates to.
+    include_classification:
+        Widens ``require_standard`` to admit classification ('C') concepts.
+        Defaults to True: a lookup exists to *recognise* vocabulary terms, and a
+        classification concept is a legitimate thing to recognise even though it
+        is not a valid mapping target. Set False for selection-shaped lookups.
+    require_active:
+        If True, excludes concepts with an ``invalid_reason``. Defaults to False
+        so recognition stays permissive — a deprecated concept that matches the
+        text can still be resolved forward through "Maps to" / "Concept replaced
+        by", whereas filtering it out here discards the term entirely.
     code_filter:
         Optional substring filter applied to concept_code (ILIKE-based). 
         Useful for coarse scoping (e.g. AJCC-only codes).
@@ -485,7 +556,9 @@ def make_concept_resolver(
         domain_id=domain_id,
         concept_class_id=concept_class_id,
         vocabulary_id=vocabulary_id,
-        standard_only=standard_only,
+        require_standard=require_standard,
+        include_classification=include_classification,
+        require_active=require_active,
         code_filter=code_filter,
         parents=parents,
         include_non_standard_descendants=include_non_standard_descendants,

--- a/tests/test_concept_filter.py
+++ b/tests/test_concept_filter.py
@@ -1,16 +1,44 @@
 """Tests for ConceptFilter.apply(), the shared CDM concept-table WHERE/LIMIT builder."""
 
+from datetime import date
+
 import pytest
 import sqlalchemy as sa
 
-from omop_alchemy.cdm.model.vocabulary import (
-    Concept,
-    ConceptView,
+from omop_alchemy.cdm.model import (
     InvalidReasonFlag,
     StandardConceptFlag,
+    normalised_flag,
     normalised_flag_expr,
 )
+from omop_alchemy.cdm.model.vocabulary import (
+    Concept,
+    Concept_Relationship,
+    ConceptView,
+    Drug_Strength,
+    Relationship,
+    Source_To_Concept_Map,
+)
 from omop_alchemy.cdm.query import ConceptFilter
+
+
+def _seed_flagged_concept(session, concept_id, *, standard_concept=None, invalid_reason=None):
+    """Add one concept carrying an arbitrary — possibly dirty — flag value."""
+    session.add(
+        Concept(
+            concept_id=concept_id,
+            concept_name=f"flag fixture {concept_id}",
+            domain_id="Condition",
+            vocabulary_id="SNOMED",
+            concept_class_id="Clinical Finding",
+            standard_concept=standard_concept,
+            concept_code=f"flag-{concept_id}",
+            valid_start_date=date(1970, 1, 1),
+            valid_end_date=date(2099, 12, 31),
+            invalid_reason=invalid_reason,
+        )
+    )
+    session.flush()
 
 
 class TestConceptFilterApply:
@@ -47,7 +75,7 @@ class TestConceptFilterApply:
         compiled = str(result).lower()
         assert "nullif" in compiled
         assert "trim" in compiled
-        assert " in " in compiled
+        assert "coalesce" in compiled
 
     def test_require_active_adds_clause(self):
         query = sa.select(Concept.concept_id)
@@ -81,15 +109,74 @@ class TestConceptFilterApply:
         assert returned_ids  # sanity: fixtures aren't empty
 
     def test_require_standard_compiles_with_literal_binds(self):
-        """Regression test: StrEnum members passed to .in_() must render as
-        plain string literals, not enum reprs, so query.compile(literal_binds=
-        True) (used for debug logging) doesn't raise a CompileError."""
+        """The standard filter must compile to the standard flag only."""
         query = sa.select(Concept.concept_id)
         result = ConceptFilter(require_standard=True).apply(query)
 
         compiled = str(result.compile(compile_kwargs={"literal_binds": True}))
         assert "'S'" in compiled
+        assert "'C'" not in compiled
+
+    def test_include_classification_widens_to_the_union(self):
+        """include_classification restores the pre-1.x 'S' or 'C' behaviour."""
+        query = sa.select(Concept.concept_id)
+        result = ConceptFilter(
+            require_standard=True, include_classification=True
+        ).apply(query)
+
+        compiled = str(result.compile(compile_kwargs={"literal_binds": True}))
+        assert "'S'" in compiled
         assert "'C'" in compiled
+        assert " OR " in compiled.upper()
+
+    def test_include_classification_is_inert_without_require_standard(self):
+        """It widens require_standard; alone it imposes no constraint at all."""
+        query = sa.select(Concept.concept_id)
+        result = ConceptFilter(include_classification=True).apply(query)
+
+        assert str(result) == str(query)
+
+    def test_include_classification_matches_the_legacy_union(self, session):
+        """The composed union must reproduce the old ``IN ('S', 'C')`` result set
+        exactly, so callers can restore prior behaviour by opting in."""
+        for offset, flag in enumerate(("S", "C", None, "", "   ", "X"), start=1):
+            _seed_flagged_concept(session, 930000 + offset, standard_concept=flag)
+
+        union_ids = set(
+            session.scalars(
+                ConceptFilter(
+                    require_standard=True, include_classification=True
+                ).apply(sa.select(Concept.concept_id))
+            ).all()
+        )
+        legacy_ids = set(
+            session.scalars(
+                sa.select(Concept.concept_id).where(
+                    normalised_flag_expr(Concept.standard_concept).in_(("S", "C"))
+                )
+            ).all()
+        )
+
+        assert union_ids == legacy_ids
+        # Sanity: the fixture actually contains both flags, so this is not a
+        # vacuous comparison of two empty sets.
+        assert 930001 in union_ids and 930002 in union_ids
+
+    def test_require_standard_alone_excludes_classification(self, session):
+        """Default behaviour: 'C' is not a valid mapping target."""
+        _seed_flagged_concept(session, 931001, standard_concept="S")
+        _seed_flagged_concept(session, 931002, standard_concept="C")
+
+        returned = set(
+            session.scalars(
+                ConceptFilter(require_standard=True).apply(
+                    sa.select(Concept.concept_id)
+                )
+            ).all()
+        )
+
+        assert 931001 in returned
+        assert 931002 not in returned
 
     def test_limit_is_applied(self):
         query = sa.select(Concept.concept_id)
@@ -107,6 +194,9 @@ class TestConceptFilterApply:
         assert not ConceptFilter(domains=("Drug",)).is_empty()
         assert not ConceptFilter(require_standard=True).is_empty()
         assert not ConceptFilter(require_active=True).is_empty()
+        # include_classification widens require_standard rather than
+        # constraining on its own, so it must not make a filter non-empty.
+        assert ConceptFilter(include_classification=True).is_empty()
 
 
 class TestNormalisedFlagExpr:
@@ -132,23 +222,41 @@ class TestNormalisedFlagExpr:
 
 
 class TestConceptViewFlags:
-    """ConceptView.is_standard/is_valid must agree with StandardConceptFlag /
-    the OMOP definition of "standard" (S or C), not just a single literal."""
+    """ConceptView flags must distinguish standard and classification concepts."""
 
     @pytest.mark.parametrize(
         "standard_concept, expected",
         [
             (StandardConceptFlag.STANDARD, True),
-            (StandardConceptFlag.CLASSIFICATION, True),
             (f" {StandardConceptFlag.STANDARD} ", True),
+            (StandardConceptFlag.CLASSIFICATION, False),
+            (f" {StandardConceptFlag.CLASSIFICATION} ", False),
             (None, False),
             ("", False),
             ("   ", False),
+            ("X", False),
         ],
     )
     def test_is_standard(self, standard_concept, expected):
         cv = ConceptView(standard_concept=standard_concept)
         assert cv.is_standard is expected
+
+    @pytest.mark.parametrize(
+        "standard_concept, expected",
+        [
+            (StandardConceptFlag.CLASSIFICATION, True),
+            (f" {StandardConceptFlag.CLASSIFICATION} ", True),
+            (StandardConceptFlag.STANDARD, False),
+            (f" {StandardConceptFlag.STANDARD} ", False),
+            (None, False),
+            ("", False),
+            ("   ", False),
+            ("X", False),
+        ],
+    )
+    def test_is_classification(self, standard_concept, expected):
+        cv = ConceptView(standard_concept=standard_concept)
+        assert cv.is_classification is expected
 
     @pytest.mark.parametrize(
         "invalid_reason, expected",
@@ -182,17 +290,213 @@ class TestConceptViewFlags:
     )
     def test_is_standard_agrees_with_require_standard_filter(self, session, standard_concept):
         """Same consistency check as above, for is_standard/require_standard."""
-        # bool(...): a bare SELECT surfaces SQL's three-valued IN() as NULL
-        # rather than False, but a WHERE clause treats NULL the same as
-        # False (row excluded) - so this coercion mirrors WHERE semantics.
         included_by_filter = bool(
             session.scalar(
                 sa.select(
-                    normalised_flag_expr(sa.literal(standard_concept, type_=sa.String)).in_(
-                        [flag.value for flag in StandardConceptFlag]
+                    sa.func.coalesce(
+                        normalised_flag_expr(
+                            sa.literal(standard_concept, type_=sa.String)
+                        )
+                        == StandardConceptFlag.STANDARD.value,
+                        sa.false(),
                     )
                 )
             )
         )
         cv = ConceptView(standard_concept=standard_concept)
         assert cv.is_standard == included_by_filter
+
+
+class TestPredicateComplement:
+    """The ``_expr`` predicates must be two-valued.
+
+    ``nullif(trim(col), '') = 'S'`` evaluates to SQL NULL for an unset flag, so a
+    bare ``NOT`` over it silently drops every unset-flag row instead of returning
+    it. The predicates coalesce to false to close that hole; these tests pin it,
+    because the failure is invisible in a plain WHERE clause.
+    """
+
+    FLAGS = ("S", "C", None, "", "   ", "X")
+
+    def _seed_all_flags(self, session, base):
+        for offset, flag in enumerate(self.FLAGS, start=1):
+            _seed_flagged_concept(session, base + offset, standard_concept=flag)
+
+    def _count(self, session, expr):
+        return session.scalar(
+            sa.select(sa.func.count()).select_from(Concept).where(expr)
+        )
+
+    def test_is_standard_negation_returns_the_complement(self, session):
+        self._seed_all_flags(session, 940000)
+        total = session.scalar(sa.select(sa.func.count()).select_from(Concept))
+
+        matching = self._count(session, Concept.is_standard_expr())
+        complement = self._count(session, sa.not_(Concept.is_standard_expr()))
+
+        assert matching + complement == total
+        assert complement > 0  # unset-flag rows must survive the negation
+
+    def test_is_classification_negation_returns_the_complement(self, session):
+        self._seed_all_flags(session, 941000)
+        total = session.scalar(sa.select(sa.func.count()).select_from(Concept))
+
+        matching = self._count(session, Concept.is_classification_expr())
+        complement = self._count(session, sa.not_(Concept.is_classification_expr()))
+
+        assert matching + complement == total
+        assert matching > 0
+
+    def test_standard_and_classification_are_disjoint(self, session):
+        self._seed_all_flags(session, 942000)
+
+        both = self._count(
+            session,
+            sa.and_(Concept.is_standard_expr(), Concept.is_classification_expr()),
+        )
+        assert both == 0
+
+    @pytest.mark.parametrize("flag", FLAGS)
+    def test_python_and_sql_agree(self, session, flag):
+        """The property and the expression must never disagree for any input."""
+        concept_id = 943000 + abs(hash(str(flag))) % 900
+        _seed_flagged_concept(session, concept_id, standard_concept=flag)
+
+        row = session.execute(
+            sa.select(
+                Concept.is_standard_expr().label("sql_standard"),
+                Concept.is_classification_expr().label("sql_classification"),
+            ).where(Concept.concept_id == concept_id)
+        ).one()
+        concept = session.get(Concept, concept_id)
+
+        assert concept.is_standard is bool(row.sql_standard)
+        assert concept.is_classification is bool(row.sql_classification)
+
+
+class TestRelationshipFlagPredicates:
+    """``relationship.is_hierarchical`` / ``defines_ancestry`` hold '1'/'0' as
+    *text*. ``'0'`` is truthy in Python, so a bare ``bool()`` on the raw column
+    reports every relationship as hierarchical — the defect these predicates
+    exist to make unreachable.
+    """
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("1", True),
+            (" 1 ", True),
+            ("0", False),
+            (" 0 ", False),
+            ("", False),
+            ("   ", False),
+            (None, False),
+            ("X", False),
+        ],
+    )
+    def test_is_hierarchical_relationship(self, raw, expected):
+        rel = Relationship(is_hierarchical=raw)
+        assert rel.is_hierarchical_relationship is expected
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [("1", True), (" 1 ", True), ("0", False), ("", False), (None, False)],
+    )
+    def test_is_ancestry_defining(self, raw, expected):
+        rel = Relationship(defines_ancestry=raw)
+        assert rel.is_ancestry_defining is expected
+
+    def test_zero_string_is_not_truthy_through_the_predicate(self):
+        """Guards the exact bug: bool('0') is True, the predicate must not be."""
+        rel = Relationship(is_hierarchical="0", defines_ancestry="0")
+        assert bool(rel.is_hierarchical) is True  # the raw column, as stored
+        assert rel.is_hierarchical_relationship is False
+        assert rel.is_ancestry_defining is False
+
+    def test_expressions_compile_to_the_true_flag_only(self):
+        for expr in (
+            Relationship.is_hierarchical_relationship_expr(),
+            Relationship.is_ancestry_defining_expr(),
+        ):
+            compiled = str(expr.compile(compile_kwargs={"literal_binds": True}))
+            assert "'1'" in compiled
+            assert "'0'" not in compiled
+            assert "coalesce" in compiled.lower()
+
+    def test_defines_ancestry_expr_discriminates_in_sql(self, session):
+        """Fixtures carry one ancestry-defining and one non-defining relationship."""
+        defining = set(
+            session.scalars(
+                sa.select(Relationship.relationship_id).where(
+                    Relationship.is_ancestry_defining_expr()
+                )
+            ).all()
+        )
+        all_ids = set(session.scalars(sa.select(Relationship.relationship_id)).all())
+
+        assert defining
+        assert defining != all_ids  # the '0' row must be excluded
+
+    def test_python_and_sql_agree(self, session):
+        for rel in session.scalars(sa.select(Relationship)).all():
+            sql_value = session.scalar(
+                sa.select(Relationship.is_ancestry_defining_expr()).where(
+                    Relationship.relationship_id == rel.relationship_id
+                )
+            )
+            assert rel.is_ancestry_defining is bool(sql_value)
+
+
+class TestInvalidReasonMixin:
+    """``InvalidReasonMixin`` is the single implementation of the validity rule
+    for every CDM table carrying ``invalid_reason``."""
+
+    MIXED_IN = (Concept, Concept_Relationship, Drug_Strength, Source_To_Concept_Map)
+
+    @pytest.mark.parametrize("model", MIXED_IN, ids=lambda m: m.__name__)
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            (None, True),
+            ("", True),
+            ("   ", True),
+            (InvalidReasonFlag.DELETED, False),
+            (InvalidReasonFlag.UPDATED, False),
+            (" D ", False),
+            ("X", False),
+        ],
+    )
+    def test_is_valid_is_identical_across_tables(self, model, raw, expected):
+        assert model(invalid_reason=raw).is_valid is expected
+
+    @pytest.mark.parametrize("model", MIXED_IN, ids=lambda m: m.__name__)
+    def test_is_valid_expr_targets_its_own_table(self, model):
+        compiled = str(model.is_valid_expr()).lower()
+        assert f"{model.__tablename__}.invalid_reason" in compiled
+        assert "is null" in compiled
+
+    @pytest.mark.parametrize("model", MIXED_IN, ids=lambda m: m.__name__)
+    def test_python_and_sql_agree_on_blank(self, session, model):
+        """A blank string is *not* SQL NULL — the case a raw ``IS NULL`` test
+        gets wrong, and the reason the normalisation exists."""
+        for raw in (None, "", "   ", "D"):
+            sql_value = session.scalar(
+                sa.select(
+                    normalised_flag_expr(sa.literal(raw, type_=sa.String)).is_(None)
+                )
+            )
+            assert model(invalid_reason=raw).is_valid is bool(sql_value)
+
+
+class TestNormalisedFlagPairing:
+    """``normalised_flag`` is the published Python counterpart to
+    ``normalised_flag_expr``; the two must never diverge."""
+
+    @pytest.mark.parametrize(
+        "raw", [None, "", " ", "   ", "S", " S ", "C", "D", "1", "0", "X", " X "]
+    )
+    def test_python_matches_sql(self, session, raw):
+        sql_value = session.scalar(
+            sa.select(normalised_flag_expr(sa.literal(raw, type_=sa.String)))
+        )
+        assert normalised_flag(raw) == sql_value

--- a/tests/test_concept_groups.py
+++ b/tests/test_concept_groups.py
@@ -339,3 +339,57 @@ def test_radiotherapy_spec_matches_governed_group():
     assert set(RADIOTHERAPY_PROCEDURES.parent_ids()) == set(
         runtime.cancer_procedures.radiotherapy.parent_ids
     )
+
+
+# ── standardness flags ──────────────────────────────────────────────────────
+#
+# ConceptGroupSpec shares its standardness vocabulary with LookupSpec and
+# ConceptFilter: require_standard / include_classification. These pin that the
+# names mean the same thing here as everywhere else in the package.
+
+def _rendered(spec) -> str:
+    """Compile the group's membership predicate to inspectable SQL."""
+    column = sa.column("concept_id")
+    return str(
+        spec.expression_for(column).compile(
+            compile_kwargs={"literal_binds": True}
+        )
+    ).lower()
+
+
+def test_require_standard_defaults_off_and_adds_no_join():
+    """Historical oncology behaviour: read concept_ancestor unfiltered."""
+    spec = _spec()
+
+    assert spec.require_standard is False
+    assert "join" not in _rendered(spec)
+
+
+def test_require_standard_joins_concept_and_filters_on_the_flag():
+    spec = _spec(require_standard=True)
+    rendered = _rendered(spec)
+
+    assert "join" in rendered
+    assert "'s'" in rendered
+
+
+def test_include_classification_defaults_on_and_widens_the_predicate():
+    """A group anchored on a classification node must not silently lose it."""
+    spec = _spec(require_standard=True)
+
+    assert spec.include_classification is True
+    rendered = _rendered(spec)
+    assert "'s'" in rendered and "'c'" in rendered
+    assert " or " in rendered
+
+
+def test_include_classification_off_narrows_to_standard_only():
+    rendered = _rendered(_spec(require_standard=True, include_classification=False))
+
+    assert "'s'" in rendered
+    assert "'c'" not in rendered
+
+
+def test_include_classification_is_inert_without_require_standard():
+    """It widens require_standard; alone it constrains nothing."""
+    assert _rendered(_spec(include_classification=True)) == _rendered(_spec())

--- a/tests/test_concept_lookup.py
+++ b/tests/test_concept_lookup.py
@@ -1,0 +1,202 @@
+"""Lookup construction over OMOP vocabulary concepts."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import sqlalchemy as sa
+
+from omop_alchemy.cdm.model.vocabulary import Concept, Concept_Synonym
+from omop_alchemy.cdm.query import ConceptFilter
+from omop_alchemy.toolkit.core.concepts import LookupSpec, OMOPConceptSource
+
+
+def _concept(
+    concept_id: int,
+    *,
+    concept_name: str,
+    domain_id: str = "Condition",
+    vocabulary_id: str = "SNOMED",
+    standard_concept: str | None = "S",
+    invalid_reason: str | None = None,
+) -> Concept:
+    return Concept(
+        concept_id=concept_id,
+        concept_name=concept_name,
+        domain_id=domain_id,
+        vocabulary_id=vocabulary_id,
+        concept_class_id="Clinical Finding",
+        standard_concept=standard_concept,
+        concept_code=f"C{concept_id}",
+        valid_start_date=date(1970, 1, 1),
+        valid_end_date=date(2099, 12, 31),
+        invalid_reason=invalid_reason,
+    )
+
+
+def test_lookup_standard_and_active_use_shared_predicates(session):
+    session.add_all(
+        [
+            _concept(910001, concept_name="Classification concept", standard_concept=" C "),
+            _concept(910002, concept_name="Deprecated concept", invalid_reason="D"),
+            _concept(910003, concept_name="Blank standard concept", standard_concept=" "),
+        ]
+    )
+    session.flush()
+
+    default_index = OMOPConceptSource.build_lookup(
+        session,
+        LookupSpec(
+            name="default",
+            domain_id="Condition",
+            include=("concept_name",),
+        ),
+    )
+    active_only_index = OMOPConceptSource.build_lookup(
+        session,
+        LookupSpec(
+            name="active_only",
+            domain_id="Condition",
+            require_active=True,
+            include=("concept_name",),
+        ),
+    )
+
+    # Recognition is permissive by default. A classification concept and a
+    # deprecated concept both resolve, so the caller keeps the hit and can
+    # follow "Maps to" / "Concept replaced by" to a valid target. Filtering
+    # either out here would discard the term with nothing to resolve forward.
+    assert default_index.lookup("classification concept") == 910001
+    assert default_index.lookup("deprecated concept") == 910002
+
+    # Standardness is still normalised: a blank flag is not standard, so it is
+    # excluded by require_standard regardless of the permissive validity default.
+    assert default_index.lookup("blank standard concept") == 0
+
+    # Selection-shaped callers opt in to the strict rule.
+    assert active_only_index.lookup("deprecated concept") == 0
+    assert active_only_index.lookup("classification concept") == 910001
+
+
+def test_synonym_lookup_is_scoped_to_indexed_concepts(session):
+    session.add_all(
+        [
+            _concept(920001, concept_name="Scoped concept"),
+            _concept(920002, concept_name="Outside concept", domain_id="Race"),
+            Concept_Synonym(
+                concept_id=920001,
+                concept_synonym_name="Scoped synonym",
+                language_concept_id=0,
+            ),
+            Concept_Synonym(
+                concept_id=920002,
+                concept_synonym_name="Outside synonym",
+                language_concept_id=0,
+            ),
+        ]
+    )
+    session.flush()
+
+    statements: list[str] = []
+
+    def capture_sql(_conn, _cursor, statement, _parameters, _context, _executemany):
+        if "concept_synonym" in statement.lower():
+            statements.append(statement.lower())
+
+    engine = session.get_bind().engine
+    sa.event.listen(engine, "before_cursor_execute", capture_sql)
+    try:
+        index = OMOPConceptSource.build_lookup(
+            session,
+            LookupSpec(
+                name="synonyms",
+                domain_id="Condition",
+                include=("concept_name",),
+                include_synonyms=True,
+            ),
+        )
+    finally:
+        sa.event.remove(engine, "before_cursor_execute", capture_sql)
+
+    assert index.lookup("scoped synonym") == 920001
+    assert index.lookup("outside synonym") == 0
+    assert statements
+    assert any(" join " in statement for statement in statements)
+
+
+def _fetch(session, **kwargs) -> set[int]:
+    return {
+        row.concept_id
+        for row in OMOPConceptSource.fetch_concepts(
+            session,
+            domain_id="Condition",
+            vocabulary_id=("SNOMED",),
+            require_standard=True,
+            **kwargs,
+        )
+    }
+
+
+def test_fetch_concepts_delegates_shared_predicates_to_concept_filter(session):
+    """Both standardness and validity flags must reach ConceptFilter unchanged.
+
+    Seeds a concept for each flag state so the comparison is not four copies of
+    the same all-standard, all-active fixture set.
+    """
+    session.add_all(
+        [
+            _concept(950001, concept_name="Strict standard"),
+            _concept(950002, concept_name="Classification", standard_concept="C"),
+            _concept(950003, concept_name="Deprecated", invalid_reason="D"),
+            _concept(950004, concept_name="Padded standard", standard_concept=" S "),
+        ]
+    )
+    session.flush()
+
+    for include_classification in (False, True):
+        for require_active in (False, True):
+            filtered = set(
+                session.execute(
+                    ConceptFilter(
+                        domains=("Condition",),
+                        vocabularies=("SNOMED",),
+                        require_standard=True,
+                        include_classification=include_classification,
+                        require_active=require_active,
+                    ).apply(sa.select(Concept.concept_id))
+                )
+                .scalars()
+                .all()
+            )
+            fetched = _fetch(
+                session,
+                include_classification=include_classification,
+                require_active=require_active,
+            )
+            assert fetched == filtered, (include_classification, require_active)
+
+    permissive = _fetch(session, include_classification=True, require_active=False)
+    strict = _fetch(session, include_classification=False, require_active=True)
+
+    # The flags genuinely move rows, so the equalities above are not vacuous.
+    assert 950002 in permissive and 950002 not in strict  # classification
+    assert 950003 in permissive and 950003 not in strict  # deprecated
+    # A whitespace-padded 'S' is standard under both — the normalisation the old
+    # hand-rolled ``standard_concept == "S"`` comparison got wrong.
+    assert 950004 in permissive and 950004 in strict
+
+
+def test_fetch_concepts_defaults_are_permissive(session):
+    """Recognition-shaped defaults: classification in, validity unfiltered."""
+    session.add_all(
+        [
+            _concept(960001, concept_name="Default classification", standard_concept="C"),
+            _concept(960002, concept_name="Default deprecated", invalid_reason="D"),
+        ]
+    )
+    session.flush()
+
+    defaults = _fetch(session)
+
+    assert 960001 in defaults
+    assert 960002 in defaults

--- a/tests/test_concept_validation.py
+++ b/tests/test_concept_validation.py
@@ -1,11 +1,11 @@
 """Tests for ConceptValidationMixin._non_standard_concepts_for_column, the
 referenced-concept standard-concept check.
 
-Regression coverage for the §3.1 behaviour change: ConceptValidationMixin now
+Regression coverage for the standard-concept predicate change: ConceptValidationMixin now
 delegates to Concept.is_standard_expr() instead of its own hand-rolled check,
-closing two bugs (blank/whitespace flags and non-canonical values such as 'X'
-previously passed as valid) without reopening the NULL three-valued-logic trap
-that motivated is_not(True) over sa.not_(...).
+so classification concepts are rejected as mapping targets alongside blank,
+whitespace, and non-canonical values such as 'X', without reopening the NULL
+three-valued-logic trap that motivated is_not(True) over sa.not_(...).
 
 _non_standard_concepts_for_column takes its table/column as plain parameters
 and does not use ``cls``, so it is exercised directly on
@@ -73,7 +73,7 @@ def _violations_for(session, condition_occurrence_id) -> set[int]:
     "case_id, standard_concept, expect_flagged",
     [
         (1, "S", False),
-        (2, "C", False),
+        (2, "C", True),
         (3, None, True),
         (4, "", True),
         (5, "   ", True),
@@ -83,11 +83,12 @@ def _violations_for(session, condition_occurrence_id) -> set[int]:
 def test_non_standard_concepts_for_column_matches_is_standard_expr(
     session, case_id, standard_concept, expect_flagged
 ):
-    """Pins the §3.1 behaviour change: blank, whitespace, and 'X' are now
-    correctly flagged as non-standard (previously bugs let them through),
-    while 'S'/'C' remain accepted. A NULL standard_concept must still be
-    flagged — the sa.not_(...) form this replaced would have silently missed
-    it, since NOT (x IN (...)) is NULL, not TRUE, when x is NULL."""
+    """Python and SQL predicates agree, and only ``S`` is a mapping target.
+
+    The explicit negation assertion protects the complement semantics for
+    NULL and blank values, where a bare SQL ``NOT`` can otherwise produce
+    NULL instead of ``TRUE``.
+    """
     concept_id = 900000 + case_id
     condition_occurrence_id = 800000 + case_id
     _seed_dirty_concept(session, concept_id, standard_concept)
@@ -97,6 +98,26 @@ def test_non_standard_concepts_for_column_matches_is_standard_expr(
         condition_concept_id=concept_id,
         type_concept_id=_type_concept_id(session),
     )
+
+    concept = session.get(Concept, concept_id)
+    assert concept is not None
+    expected_standard = standard_concept is not None and standard_concept.strip() == "S"
+    expected_classification = (
+        standard_concept is not None and standard_concept.strip() == "C"
+    )
+    assert concept.is_standard is expected_standard
+    assert concept.is_classification is expected_classification
+
+    sql_standard, sql_classification, sql_not_standard = session.execute(
+        sa.select(
+            Concept.is_standard_expr(),
+            Concept.is_classification_expr(),
+            ~Concept.is_standard_expr(),
+        ).where(Concept.concept_id == concept_id)
+    ).one()
+    assert bool(sql_standard) is expected_standard
+    assert bool(sql_classification) is expected_classification
+    assert bool(sql_not_standard) is not expected_standard
 
     violations = _violations_for(session, condition_occurrence_id)
     assert (concept_id in violations) is expect_flagged


### PR DESCRIPTION
## Summary

closes #52, #51, #51 

## Checklist

- [x] Applied exactly one label (`breaking`, `feature`, `fix`, `dependencies`, or `chore`)
- [x] Tests pass locally (`uv run pytest -q`)
- [x] Lint passes (`uv run ruff check .`)
